### PR TITLE
the `5555 <---[ THING ]---- 5555` revelation is too enlightening

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Programs have a harder time. You can't keep piping json into a protobuf decoder 
 Because they're the same thing. Which one of these is the encoder and which the decoder?
 
     5555 ----[ THING ]---> 8888
-    5555 <---[ THING ]---- 5555
+    5555 <---[ THING ]---- 8888


### PR DESCRIPTION
I believe that the question “Which one of these is the encoder and which the decoder?” becomes really deep when `5555 <---[ THING ]---- 5555` is presented as one of the examples.

That THING does not seem to encode and decode anything. A fan of zen might call it 無駄、 a workless work.

Such revelation is really enlightening but it probably carries the wrong message and that example should actually mirror the previous `5555 ----[ THING ]---> 8888` instead of its current form.