### PR TITLE
Add blake range codes

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -46,8 +46,8 @@ keccak-256,         ,                         0x1B
 keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 ,, Note: keccak has variable output length. The number specifies the core length
-blake2b-lenX,       ,                         0xb201-0xb240
-blake2s-lenX,       ,                         0xb241-0xb260
+blake2b-X,X is length in bits, can take values from 8 to 512 in 8 bit increments,0xb201-0xb240 (0xb201 - blake2b-8, 0xb240 - blake2b-512)
+blake2s-X,X is length in bits, can take values from 8 to 256 in 8 bit increments,0xb241-0xb260 (0xb241 - blake2s-8, 0xb260 - blake2b-256)
 reserved for apps,  appl specific range,      0x4000-0x40f0
 
 multiaddrs,,

--- a/table.csv
+++ b/table.csv
@@ -46,8 +46,8 @@ keccak-256,         ,                         0x1B
 keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 ,, Note: keccak has variable output length. The number specifies the core length
-blake2b,            ,                         0x40
-blake2s,            ,                         0x41
+blake2b-lenX,       ,                         0xb201-0xb240
+blake2s-lenX,       ,                         0xb241-0xb260
 reserved for apps,  appl specific range,      0x4000-0x40f0
 
 multiaddrs,,

--- a/table.csv
+++ b/table.csv
@@ -46,8 +46,8 @@ keccak-256,         ,                         0x1B
 keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 ,, Note: keccak has variable output length. The number specifies the core length
-blake2b-X,X is length in bits, can take values from 8 to 512 in 8 bit increments,"0xb201-0xb240 (0xb201 - blake2b-8, 0xb240 - blake2b-512)"
-blake2s-X,X is length in bits, can take values from 8 to 256 in 8 bit increments,"0xb241-0xb260 (0xb241 - blake2s-8, 0xb260 - blake2b-256)"
+blake2b-X,"X is length in bits, can take values from 8 to 512 in 8 bit increments","0xb201-0xb240 (0xb201 - blake2b-8, 0xb240 - blake2b-512)"
+blake2s-X,"X is length in bits, can take values from 8 to 256 in 8 bit increments","0xb241-0xb260 (0xb241 - blake2s-8, 0xb260 - blake2b-256)"
 reserved for apps,  appl specific range,      0x4000-0x40f0
 
 multiaddrs,,

--- a/table.csv
+++ b/table.csv
@@ -46,8 +46,8 @@ keccak-256,         ,                         0x1B
 keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 ,, Note: keccak has variable output length. The number specifies the core length
-blake2b-X,X is length in bits, can take values from 8 to 512 in 8 bit increments,0xb201-0xb240 (0xb201 - blake2b-8, 0xb240 - blake2b-512)
-blake2s-X,X is length in bits, can take values from 8 to 256 in 8 bit increments,0xb241-0xb260 (0xb241 - blake2s-8, 0xb260 - blake2b-256)
+blake2b-X,X is length in bits, can take values from 8 to 512 in 8 bit increments,"0xb201-0xb240 (0xb201 - blake2b-8, 0xb240 - blake2b-512)"
+blake2s-X,X is length in bits, can take values from 8 to 256 in 8 bit increments,"0xb241-0xb260 (0xb241 - blake2s-8, 0xb260 - blake2b-256)"
 reserved for apps,  appl specific range,      0x4000-0x40f0
 
 multiaddrs,,


### PR DESCRIPTION
Blake2s and Blake2b have different initial vectors states for different lengths, this means that for each chosen output length it looks like completely different hash function.

This proposal allocated 64 values for Blake2b and 32 values for Blake2s as those are the ranges the outputs can be chosen from.

Those codes will require 3 bytes to write down as varints.