### PR TITLE
Edited README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # multicodec
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
-> compact self-describing codecs. Save space by using predefined multicodec tables.
+> Compact self-describing codecs. Save space by using predefined multicodec tables.
 
 ## Table of Contents
 
@@ -68,7 +69,7 @@ This ["first come, first assign"](https://github.com/multiformats/multicodec/pul
 
 - [go](https://github.com/multiformats/go-multicodec/)
 - [JavaScript](https://github.com/multiformats/js-multicodec)
-- [Add yours today!](https://github.com/multiformats/multicodec/edit/master/multicodec.md)
+- [Add yours today!](https://github.com/multiformats/multicodec/edit/master/table.csv)
 
 ## Multicodec Path, also known as [`multistream`](https://github.com/multiformats/multistream)
 
@@ -108,6 +109,8 @@ Contributions welcome. Please check out [the issues](https://github.com/multifor
 
 Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
 ## License
 
-[MIT](LICENSE)
+This repository is only for documents. All of these are licensed under the [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license © 2016 Protocol Labs Inc. Any code is under a [MIT](LICENSE) © 2016 Protocol Labs Inc.


### PR DESCRIPTION
- Fixed https issue in links
- Added standard-readme badge
- Changed descrption by capitalizing Compact and changing on GitHub
- Fixed edit link to point to the table
- Added note about readme to contribute
- Added CC license to license section
- Added year and Protocol Labs to MIT code license