### PR TITLE
Add multihash for libp2p-crypto public key

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -178,6 +178,9 @@ IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
 
+libp2p,,
+libp2p-pubkey-hash,   Multihash of libp2p-crypto encapsulated public key, 0x0210
+
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91
 eth-tx-trie,          Ethereum Transaction Trie (Eth-Trie),             0x92


### PR DESCRIPTION
Related to ipfs/go-cid#15, I didn't realized that the codes were defined here.