### PR TITLE
Add mutable record

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -177,6 +177,7 @@ mkv,                ,                         0x
 IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
+iprs,                 Latest version of mutable record identified,      0x78
 
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91


### PR DESCRIPTION
Allow identifying mutable objects given the hash of an immutable
record definition. To avoid using too much codes, the record definition could be defined to require a multicodec header.