### PR TITLE
Add BitTorrent info metadata format as 0x7b

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -26,6 +26,7 @@ flatbuf,            FlatBuffers,              0x
 rlp,                recursive length prefix,  0x60
 msgpack,            MessagePack,              0x
 binc,               Binc,                     0x
+bencoding,          Bencoding,                0x
 
 multiformats,,
 multicodec,         ,                         0x30
@@ -194,3 +195,6 @@ zcash-block,          Zcash Block,                                      0xc0
 zcash-tx,             Zcash Tx,                                         0xc1
 stellar-block,        Stellar Block,                                    0xd0
 stellar-tx,           Stellar Tx,                                       0xd1
+
+bittorrent,           BitTorrent info metadata (bencoded),              0x7b
+


### PR DESCRIPTION
Adds BitTorrent [info metadata](http://www.bittorrent.org/beps/bep_0003.html#info-dictionary) format as `0x7b`. (Mnemonic: `B7` for <b>B</b>it<b>T</b>orrent, but transposed so the value remains one byte after [unsigned-varint](https://github.com/multiformats/unsigned-varint) encoding.) Also adds [BitTorrent's bencoding](http://www.bittorrent.org/beps/bep_0003.html#bencoding) under serialization formats, but leaves it unassigned for now.

I'm working on some software that includes a web gateway for distributed content. It will initially only serve content from BitTorrent torrents, but I'd like to eventually include interlinked IPFS content, so I intend to move to a path scheme that's as similar as possible (ideally the same/compatible) as that used by IPFS/IPLD/CIDv1.

As a first step I believe I need a multicodec assignment for the BitTorrent format, hence this PR.
