### PR TITLE
Add DHT record code

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -178,6 +178,10 @@ IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
 
+IPFS,,
+ipfs-kad-dht-record,  Key of an IPFS record in the DHT,                 0x0220
+
+Blockchain,,
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91
 eth-tx-trie,          Ethereum Transaction Trie (Eth-Trie),             0x92


### PR DESCRIPTION
As discussed in https://github.com/libp2p/go-libp2p-kad-dht/issues/50#issuecomment-282146921, I want to reference IPFS DHT records using CID. This PR allocates a code for that.