### PR TITLE
Add ed25519 public key codec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -200,3 +200,4 @@ stellar-tx,           Stellar Tx,                                       0xd1
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c
+ed25519,              Ed25519 public key,                               0xed

--- a/table.csv
+++ b/table.csv
@@ -200,4 +200,4 @@ stellar-tx,           Stellar Tx,                                       0xd1
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c
-ed25519,              Ed25519 public key,                               0xed
+ed25519-pub,          Ed25519 public key,                               0xed


### PR DESCRIPTION
See https://github.com/ipfs/notes/issues/241#issuecomment-296392217

I suggest using the code `0xed` so that's it's visually obvious and easy to remember it's associated with ed25519.