### PR TITLE
Add git-raw codec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -178,6 +178,8 @@ IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
 
+git-raw,              Raw Git object,                                   0x78
+
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91
 eth-tx-trie,          Ethereum Transaction Trie (Eth-Trie),             0x92


### PR DESCRIPTION
By raw it means uncompressed - git by default stores deflated objects, but their hash is calculated before compression.