### PR TITLE
remove incorrect base2 code

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -5,7 +5,7 @@ bin,                raw binary,               0x55
 
 bases encodings,,
 base1,              unary,                    0x01
-base2,              binary (0 and 1),         0x55
+base2,              binary (0 and 1),         0x
 base8,              octal,                    0x07
 base10,             decimal,                  0x09
 base16,             hexadecimal,              0x


### PR DESCRIPTION
not sure if there is a code for `base2` (ascii 101010101) yet but it is incorrectly set to the same as "raw binary"