### PR TITLE
bin->raw

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -1,7 +1,7 @@
 codec,              description,              code
 
 miscellaneous,,
-bin,                raw binary,               0x55
+raw,                raw binary,               0x55
 
 bases encodings,,
 base1,              unary,                    0x01


### PR DESCRIPTION
When it got implemented in `go-ipfs`, devs called it raw https://github.com/ipfs/go-ipfs/blob/master/core/coredag/dagtransl.go#L22.

It should have followed the table (or change the table first). Now, to reduce friction and make both implementations interop, we will go and update js and the table.

@kumavis lead this efforted and created the PRs for it. Thanks @kumavis!