### PR TITLE
fill out multibase table and treat multibases as symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 
 ## Protocol Description - How does the protocol work?
 
-`multicodec` is a _self-describing multiformat_, it wraps other formats with a tiny bit of self-description. A multicodec identifier is both a varint and the code identifying the following data, this means that the most significant bit of every multicodec code is reserved to signal the continuation.
+`multicodec` is a _self-describing multiformat_, it wraps other formats with a tiny bit of self-description. A multicodec identifier may either be a varint (in a byte string) or a symbol (in a text string).
 
-This way, a chunk of data identified by multicodec will look like this:
+A chunk of data identified by multicodec will look like this:
 
 ```sh
-<multicodec-varint><encoded-data>
+<multicodec><encoded-data>
 # To reduce the cognitive load, we sometimes might write the same line as:
 <mcp><data>
 ```
@@ -49,11 +49,12 @@ It is worth noting that multicodec-packed works very well in conjunction with [m
 
 ## MulticodecProtocol Tables
 
-Multicodec uses "protocol tables" to agree upon the mapping from one multicodec code (a single varint). These tables can be application specific, though -- like [with](https://github.com/multiformats/multihash) [other](https://github.com/multiformats/multibase) [multiformats](https://github.com/multiformats/multiaddr) -- we will keep a globally agreed upon table with common protocols and formats.
+Multicodec uses "protocol tables" to agree upon the mapping from one multicodec code. These tables can be application specific, though -- like [with](https://github.com/multiformats/multihash) [other](https://github.com/multiformats/multibase) [multiformats](https://github.com/multiformats/multiaddr) -- we will keep a globally agreed upon table with common protocols and formats.
 
 ## Multicodec table
 
-The full table can be found at [table.csv](/table.csv) inside this repo.
+The full table can be found at [table.csv](/table.csv) inside this repo. Codes
+prefixed with `0x` are varint multicodecs and all others are symbolic.
 
 ### Adding new multicodecs to the table
 
@@ -100,6 +101,12 @@ An Most Significant Bit unsigned varint, as defined by the [multiformats/unsigne
 > **Q. Don't we have to agree on a table of protocols?**
 
 Yes, but we already have to agree on what protocols themselves are, so this is not so hard. The table even leaves some room for custom protocol paths, or you can use your own tables. The standard table is only for common things.
+
+> **Q. Why distinguish between bytes and text?**
+
+For completeness, we consider
+[multibase](https://github.com/multiformats/multibase) prefixes to be
+multicodecs. However multibase prefixes occur in *text*, and are therefore *symbols*. They may (or may not) have some underlying binary representation but that changes based on the text encoding used.
 
 ## Maintainers
 

--- a/table.csv
+++ b/table.csv
@@ -4,17 +4,27 @@ miscellaneous,,
 raw,                raw binary,               0x55
 
 bases encodings,,
-base1,              unary,                    0x01
-base2,              binary (0 and 1),         0x00
-base8,              octal,                    0x07
-base10,             decimal,                  0x09
-base16,             hexadecimal,              0x
-base32,             rfc4648,                  0x
-base32hex,          rfc4648,                  0x
-base58flickr,       base58 flicker,           0x
-base58btc,          base58 bitcoin,           0x
-base64,             rfc4648,                  0x
-base64url,          rfc4648,                  0x
+identity,           raw binary,               NUL
+base1,              unary,                    "1"
+base2,              binary (0 and 1),         "0"
+base8,              octal,                    "7"
+base10,             decimal,                  "9"
+base16,             hexadecimal,              "f"
+base16-upper,       hexadecimal,              "F"
+base32,             rfc4648,                  "b"
+base32-upper,       rfc4648,                  "B"
+base32pad,          rfc4648,                  "c"
+base32pad-upper,    rfc4648,                  "C"
+base32hex,          rfc4648,                  "v"
+base32hex-upper,    rfc4648,                  "V"
+base32hexpad,       rfc4648,                  "t"
+base32hexpad-upper, rfc4648,                  "T"
+base58flickr,       base58 flicker,           "Z"
+base58btc,          base58 bitcoin,           "z"
+base64,             rfc4648,                  "m"
+base64pad,          rfc4648,                  "M"
+base64url,          rfc4648,                  "u"
+base64urlpad,       rfc4648,                  "U"
 
 serialization formats,,
 cbor,               CBOR,                     0x51
@@ -35,6 +45,7 @@ multiaddr,          ,                         0x32
 multibase,          ,                         0x33
 
 multihashes,,
+identity,           raw binary,               0x0
 md4,                ,                         0xd4
 md5,                ,                         0xd5
 sha1,               ,                         0x11


### PR DESCRIPTION
This extends the concept of multicodecs to general symbolic (text) strings, not just byte strings.

replaces #59

@diasdavid I've changed multibase prefixes to be "symbolic". Thoughts?

TODO: Deprecate 0x55 or 0x0? Having both is a bit annoying. They both mean "raw
binary data".