### PR TITLE
Support for Tree Tiger Hash and Merkle Hash Tree

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -63,6 +63,8 @@ keccak-256,         ,                         0x1B
 keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 murmur3,            ,                         0x22
+tiger,              ,                         0x7A
+merkle-hash-tree,   ,                         0x0400
 blake2b-8,Blake2b consists of 64 output lengths that give different hashes,0xb201
 blake2b-16,,0xb202
 blake2b-24,,0xb203


### PR DESCRIPTION
https://github.com/multiformats/multihash/issues/55

## Merkle Hash Tree multihash

`<merkle-hash-tree-mc>-<len>-(<hash-tree-type>-(<multihash>[<multihash>...]))`
`<0x0400>-<len>-(<0x01>-(<multihash>[<multihash>...]))`

0x0400 - Merkle Hash Tree (1024 decimal) multicodec value 

0x01 - Hash Tree Type with this settings:
* Data segment size - 1024 bytes
* Data prefix - one byte with value 0 (0x00)
* Hash pair prefix - one byte with value 1 (0x01)
* Unpaired hashes move on next level unchanged.
* Multihashes in tree multihash packed in breadth-first order from root to leafs.

## Tiger multihash:

`<tiger-mc>-<len>-<hash>`
`<0x7A>-<0x18>-<0x3293ac630c13f0245f92bbb1766e16167a4e58492dde73f3>`

0x7A - Tiger-hash multicodec value

## Tree Tiger multihash:
`<merkle-hash-tree-mc>-<len>-(<hash-tree-type>-(<tiger-root-multihash>[<tiger-multihash>...]))`
## Tree sha2-256 multihash:
`<merkle-hash-tree-mc>-<len>-(<hash-tree-type>-(<sha2-256-root-multihash>[<sha2-256-multihash>...]))`

## Links:
[Tree Hash EXchange format (THEX)](https://adc.sourceforge.io/draft-jchapweske-thex-02.html#anchor2)
[Tiger:
A Fast New Cryptographic Hash Function (Designed in 1995)](http://www.cs.technion.ac.il/~biham/Reports/Tiger/)
wikipedia: [Tiger (cryptography)](https://en.wikipedia.org/wiki/Tiger_(cryptography))
wikipedia: [Merkle tree#Tiger tree hash](https://en.wikipedia.org/wiki/Merkle_tree#Tiger_tree_hash)

License: MIT
Signed-off-by: Ivan <ivan386@users.noreply.github.com>