### PR TITLE
table.csv: Add "zone" multiaddr (IPv6 zone)

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -389,6 +389,7 @@ skein1024-1024,,0xb3e0
 multiaddrs,,
 ip4,                ,                         0x04
 ip6,                ,                         0x29
+ip6zone,            ,                         0x2A
 tcp,                ,                         0x06
 udp,                ,                         0x0111
 dccp,               ,                         0x21


### PR DESCRIPTION
Can be prefixed to the "ip6" protocol. See [rfc4007].

[rfc4007] https://tools.ietf.org/html/rfc4007