### PR TITLE
feat: add dag-json, fixes #80 

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -418,7 +418,7 @@ mkv,                ,                         0x
 IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
-dag-json,             MerkleDag json,                                   0x129
+dag-json,             MerkleDAG json,                                   0x129
 
 git-raw,              Raw Git object,                                   0x78
 

--- a/table.csv
+++ b/table.csv
@@ -418,6 +418,7 @@ mkv,                ,                         0x
 IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
+dag-json,             MerkleDag json,                                   0x129
 
 git-raw,              Raw Git object,                                   0x78
 


### PR DESCRIPTION
Adding `dag-json` to codec table.

See #80 for discussion.