### PR TITLE
reserve 0x2f (ASCII /) as the *path* multicodec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -20,6 +20,7 @@ murmur3-128,                    multihash,      0x22,
 murmur3-32,                     multihash,      0x23,
 ip6,                            multiaddr,      0x29,
 ip6zone,                        multiaddr,      0x2A,
+path,                           namespace,      0x2F,           Namespace for string paths. Corresponds to `/` in ASCII.
 multicodec,                     multiformat,    0x30,
 multihash,                      multiformat,    0x31,
 multiaddr,                      multiformat,    0x32,


### PR DESCRIPTION
That way, we can always tell if something is a path or something else.

We may also be able to take advantage of this later to combine a few
concepts and get rid of the "multiaddrs look like paths but are totally not"
problem. However, we can think about that later. This PR just reserves the code
so we don't run into problems later.

* Remove the distinction between string/binary multiaddrs. Instead, the "string"
  will *also* be a valid binary multiaddr.
* Define a new multipath spec to combine multiaddrs and other paths.

Related to: https://github.com/multiformats/multiaddr/issues/70