### PR TITLE
Remove questions that didn't make sense anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ In order to enable self descriptive data formats or streams that can be dynamica
 
 ## FAQ
 
-> **Q. I have questions on multicodec, not listed here.**
-
-That's not a question. But, have you checked the proper [multicodec FAQ](./README.md#faq)? Maybe your question is answered there. This FAQ is only specifically for multicodec.
-
 > **Q. Why?**
 
 Because [multistream](https://github.com/multiformats/multistream) is too long for identifiers. We needed something shorter.


### PR DESCRIPTION
Due to the removal of references to multicodec-packed in commit
[888cc045de9ea668ec2b098c00173a5eb886b0f8] the first question
doesn't make any sense anymore.

[888cc045de9ea668ec2b098c00173a5eb886b0f8]: https://github.com/multiformats/multicodec/commit/888cc045de9ea668ec2b098c00173a5eb886b0f8