### PR TITLE
Remove implementation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Because [multistream](https://github.com/multiformats/multistream) is too long f
 
 > **Q. Why varints?**
 
-So that we have no limitation on protocols. Implementation note: you do not need to implement varints until the standard multicodec table has more than 127 functions.
+So that we have no limitation on protocols.
 
 > **Q. What kind of varints?**
 


### PR DESCRIPTION
There are already multicodec codes in the table which are > 127
(Blake and Stein hashes). Hence implementations need to implement
varint.