### PR TITLE
add oinion3 and garlic64 protocol codes

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -404,6 +404,8 @@ https,              ,                         0x01BB
 quic,               ,                         0x01CC
 ws,                 ,                         0x01DD
 onion,              ,                         0x01BC
+onion3,             ,                         0x01BD
+garlic64,           ,                         0x01BE
 p2p-circuit,        ,                         0x0122
 dns4,               ,                         0x36
 dns6,               ,                         0x37


### PR DESCRIPTION
* onion3 is for v3 onion addresses
* garlic64 is for *full* i2p addresses. We may later need a garlic32 for "short" garlic addresses.

See: https://github.com/multiformats/multiaddr/pull/77

cc @eyedeekay