### PR TITLE
Write dag-json codec as two bytes

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -426,7 +426,7 @@ mkv,                ,                         0x
 IPLD formats,,
 dag-pb,               MerkleDAG protobuf,                               0x70
 dag-cbor,             MerkleDAG cbor,                                   0x71
-dag-json,             MerkleDAG json,                                   0x129
+dag-json,             MerkleDAG json,                                   0x0129
 
 git-raw,              Raw Git object,                                   0x78
 


### PR DESCRIPTION
Make it clearer (and easier to convert) that dag-json is two bytes.