### PR TITLE
feat: Add /p2p-stardust

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -386,6 +386,7 @@ dns4,               ,                         0x36
 dns6,               ,                         0x37
 dnsaddr,            ,                         0x38
 p2p-websocket-star, ,                         0x01DF
+p2p-stardust,       ,                         0x0115
 p2p-webrtc-star,    ,                         0x0113
 p2p-webrtc-direct,  ,                         0x0114
 unix,               ,                         0x0190


### PR DESCRIPTION
This is part of the endeavor to replace ws-star with the newly created stardust protocol. See libp2p/js-libp2p-websocket-star#70 for a reference

Relates to https://github.com/multiformats/multiaddr/pull/84#pullrequestreview-191887582