### PR TITLE
Add several varint prefix codes + lenghts for Holochain IDs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -427,7 +427,7 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
-holochain-address,    Holochain Address,                                0x1e
+holochain-keys,       Holochain address public keys + parity,           0x1e
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c

--- a/table.csv
+++ b/table.csv
@@ -427,6 +427,8 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
+holochain-address,    Holochain Address,                                0x1e
+
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c
 ed25519-pub,          Ed25519 public key,                               0xed

--- a/table.csv
+++ b/table.csv
@@ -427,12 +427,12 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
-holochain-key-v0,     Holochain v0 public key + 8 R-S (63 x Base-32), 0x947124
-holochain-key-v1      Holochain v1 public key + 8 R-S (63 x Base-32), 0x957124
-holochain-adr-v0,     Holochain v0 address    + 8 R-S (63 x Base-32), 0x807124
-holochain-adr-v1,     Holochain v1 address    + 8 R-S (63 x Base-32), 0x817124
-holochain-sig-v0,     Holochain v0 signature  + 8 R-S (63 x Base-32), 0xa27124
-holochain-sig-v1,     Holochain v1 signature  + 8 R-S (63 x Base-32), 0xa37124
+holochain-key-v0,     Holochain v0 public key + 8 R-S (63 x Base-32),   0x947124
+holochain-key-v1      Holochain v1 public key + 8 R-S (63 x Base-32),   0x957124
+holochain-adr-v0,     Holochain v0 address    + 8 R-S (63 x Base-32),   0x807124
+holochain-adr-v1,     Holochain v1 address    + 8 R-S (63 x Base-32),   0x817124
+holochain-sig-v0,     Holochain v0 signature  + 8 R-S (63 x Base-32),   0xa27124
+holochain-sig-v1,     Holochain v1 signature  + 8 R-S (63 x Base-32),   0xa37124
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c

--- a/table.csv
+++ b/table.csv
@@ -428,7 +428,7 @@ leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
 holochain-key-v0,     Holochain v0 public key + 8 R-S (63 x Base-32),   0x947124
-holochain-key-v1      Holochain v1 public key + 8 R-S (63 x Base-32),   0x957124
+holochain-key-v1,     Holochain v1 public key + 8 R-S (63 x Base-32),   0x957124
 holochain-adr-v0,     Holochain v0 address    + 8 R-S (63 x Base-32),   0x807124
 holochain-adr-v1,     Holochain v1 address    + 8 R-S (63 x Base-32),   0x817124
 holochain-sig-v0,     Holochain v0 signature  + 8 R-S (63 x Base-32),   0xa27124

--- a/table.csv
+++ b/table.csv
@@ -398,6 +398,15 @@ dag-json,             MerkleDAG json,                                   0x0129
 
 git-raw,              Raw Git object,                                   0x78
 
+torrent-info,         Torrent file info field (bencoded),               0x7b
+torrent-file,         Torrent file (bencoded),                          0x7c
+
+leofcoin-block,       Leofcoin Block,                                   0x81
+leofcoin-tx,          Leofcoin Transaction,                             0x82
+leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
+
+holochain-keys,       Holochain address public keys + parity (base64),  0x86
+
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91
 eth-tx-trie,          Ethereum Transaction Trie (Eth-Trie),             0x92
@@ -420,18 +429,10 @@ stellar-tx,           Stellar Tx,                                       0xd1
 decred-block,         Decred Block,                                     0xe0
 decred-tx,            Decred Tx,                                        0xe1
 
+ed25519-pub,          Ed25519 public key,                               0xed
+
 dash-block,           Dash Block,                                       0xf0
 dash-tx,              Dash Tx,                                          0xf1
-
-leofcoin-block,       Leofcoin Block,                                   0x81
-leofcoin-tx,          Leofcoin Transaction,                             0x82
-leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
-
-holochain-keys,       Holochain address public keys + parity,           0x86
-
-torrent-info,         Torrent file info field (bencoded),               0x7b
-torrent-file,         Torrent file (bencoded),                          0x7c
-ed25519-pub,          Ed25519 public key,                               0xed
 
 Content Namespaces,,
 ipld-ns,              IPLD path,                                        0xe2

--- a/table.csv
+++ b/table.csv
@@ -427,7 +427,7 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
-holochain-keys,       Holochain address public keys + parity,           0x1e
+holochain-keys,       Holochain address public keys + parity,           0x86
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c

--- a/table.csv
+++ b/table.csv
@@ -427,9 +427,7 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
-holochain-keys,       Holochain public keys + 8 R-S parity (Base58),    0x8be63448
-holochain-id,         Holochain ID + 8 R-S parity (Base58),             0xf1ae3448
-holochain-holo,       Holochain Holo ID + 8 R-S parity (Base58),        0xe3f83448
+holochain-keys,       Holochain public keys + 7 R-S parity (Base58),    0x8be63447
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c

--- a/table.csv
+++ b/table.csv
@@ -398,15 +398,6 @@ dag-json,             MerkleDAG json,                                   0x0129
 
 git-raw,              Raw Git object,                                   0x78
 
-torrent-info,         Torrent file info field (bencoded),               0x7b
-torrent-file,         Torrent file (bencoded),                          0x7c
-
-leofcoin-block,       Leofcoin Block,                                   0x81
-leofcoin-tx,          Leofcoin Transaction,                             0x82
-leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
-
-holochain-keys,       Holochain address public keys + parity (base64),  0x86
-
 eth-block,            Ethereum Block (RLP),                             0x90
 eth-block-list,       Ethereum Block List (RLP),                        0x91
 eth-tx-trie,          Ethereum Transaction Trie (Eth-Trie),             0x92
@@ -429,10 +420,20 @@ stellar-tx,           Stellar Tx,                                       0xd1
 decred-block,         Decred Block,                                     0xe0
 decred-tx,            Decred Tx,                                        0xe1
 
-ed25519-pub,          Ed25519 public key,                               0xed
-
 dash-block,           Dash Block,                                       0xf0
 dash-tx,              Dash Tx,                                          0xf1
+
+leofcoin-block,       Leofcoin Block,                                   0x81
+leofcoin-tx,          Leofcoin Transaction,                             0x82
+leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
+
+holochain-keys,       Holochain public keys + 8 R-S parity (Base58),    0x8be63448
+holochain-id,         Holochain ID + 8 R-S parity (Base58),             0xf1ae3448
+holochain-holo,       Holochain Holo ID + 8 R-S parity (Base58),        0xe3f83448
+
+torrent-info,         Torrent file info field (bencoded),               0x7b
+torrent-file,         Torrent file (bencoded),                          0x7c
+ed25519-pub,          Ed25519 public key,                               0xed
 
 Content Namespaces,,
 ipld-ns,              IPLD path,                                        0xe2

--- a/table.csv
+++ b/table.csv
@@ -427,7 +427,12 @@ leofcoin-block,       Leofcoin Block,                                   0x81
 leofcoin-tx,          Leofcoin Transaction,                             0x82
 leofcoin-pr,          Leofcoin Peer Reputation,                         0x83
 
-holochain-keys,       Holochain public keys + 7 R-S parity (Base58),    0x8be63447
+holochain-key-v0,     Holochain v0 public key + 8 R-S (63 x Base-32), 0x947124
+holochain-key-v1      Holochain v1 public key + 8 R-S (63 x Base-32), 0x957124
+holochain-adr-v0,     Holochain v0 address    + 8 R-S (63 x Base-32), 0x807124
+holochain-adr-v1,     Holochain v1 address    + 8 R-S (63 x Base-32), 0x817124
+holochain-sig-v0,     Holochain v0 signature  + 8 R-S (63 x Base-32), 0xa27124
+holochain-sig-v1,     Holochain v1 signature  + 8 R-S (63 x Base-32), 0xa37124
 
 torrent-info,         Torrent file info field (bencoded),               0x7b
 torrent-file,         Torrent file (bencoded),                          0x7c


### PR DESCRIPTION
Holochain is an open source framework for building fully distributed, peer-to-peer applications.  See https://holo.host for more background.

We will be launching in the next few months, and would like our Holochain node Addresses to have the 0x86 prefix, if possible.  That, along with our 70-byte long core keys+parity data will result in a multicodec prefix of 0x8646.  When base-64 encoded, this yields Addresses with prefix "hkZ...", which is useful for our users to help them quickly identify potential Holochain Addresses.

Thanks for your consideration!