### PR TITLE
Use '#!/usr/bin/env python3' vs. fixed path '/usr/bin/python3'

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import csv
 import sys


### PR DESCRIPTION
Many installations have python3 installed elsewhere, such as /usr/local/bin/, etc.  Use the environment PATH variable to locate, using /usr/bin/env.