### PR TITLE
Update table.csv

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -35,6 +35,10 @@ keccak-384,         ,                         0x1C
 keccak-512,         ,                         0x1D
 murmur3-128,        ,                         0x22
 murmur3-32,         ,                         0x23
+ripemd-128,         ,                         0x26
+ripemd-160,         ,                         0x27
+ripemd-256,         ,                         0x28
+ripemd-320,         ,                         0x29
 x11,                ,                         0x1100
 
 blake2b-8,Blake2b consists of 64 output lengths that give different hashes,0xb201


### PR DESCRIPTION
Added the RIPEMD cryptographic hash functions 
RIPEMD-160 is the base hash encoding for Bitcoin addresses.