### PR TITLE
Add Swarm multicodecs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -68,6 +68,8 @@ swarm-ns,                       namespace,      0xe4,           Swarm path
 ed25519-pub,                    key,            0xed,           Ed25519 public key
 dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
+swarm-manifest,                 swarm,          0xfa,           Swarm Manifest
+swarm-feed,                     swarm,          0xfb,           Swarm Feed
 udp,                            multiaddr,      0x0111,
 p2p-webrtc-star,                multiaddr,      0x0113,
 p2p-webrtc-direct,              multiaddr,      0x0114,

--- a/table.csv
+++ b/table.csv
@@ -60,6 +60,7 @@ stellar-block,                  ipld,           0xd0,           Stellar Block
 stellar-tx,                     ipld,           0xd1,           Stellar Tx
 md4,                            multihash,      0xd4,
 md5,                            multihash,      0xd5,
+bmt,                            multihash,      0xd6,           Binary Merkle Tree Hash
 decred-block,                   ipld,           0xe0,           Decred Block
 decred-tx,                      ipld,           0xe1,           Decred Tx
 ipld-ns,                        namespace,      0xe2,           IPLD path
@@ -68,8 +69,8 @@ swarm-ns,                       namespace,      0xe4,           Swarm path
 ed25519-pub,                    key,            0xed,           Ed25519 public key
 dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
-swarm-manifest,                 swarm,          0xfa,           Swarm Manifest
-swarm-feed,                     swarm,          0xfb,           Swarm Feed
+swarm-manifest,                 ipld,           0xfa,           Swarm Manifest
+swarm-feed,                     ipld,           0xfb,           Swarm Feed
 udp,                            multiaddr,      0x0111,
 p2p-webrtc-star,                multiaddr,      0x0113,
 p2p-webrtc-direct,              multiaddr,      0x0114,


### PR DESCRIPTION
Hi,

I'd like to add these two Swarm primitive types that we'd like to be able to reference from ENS resolver contracts.

Please let me know if I should shift the codes around (although obviously lower numbers = less data on chain).

Cheers