### PR TITLE
Reserve multicodec for filecoin compact serialization format

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -15,6 +15,7 @@ keccak-224,                     multihash,      0x1A,           keccak has varia
 keccak-256,                     multihash,      0x1B,
 keccak-384,                     multihash,      0x1C,
 keccak-512,                     multihash,      0x1D,
+filecoin compact serialization, ipld,           0x1F,
 dccp,                           multiaddr,      0x21,
 murmur3-128,                    multihash,      0x22,
 murmur3-32,                     multihash,      0x23,


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/specs/pull/131

Note that we're only using one multicodec here, not one per object type. 