### PR TITLE
remove bmt in favor of using keccak256

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -60,7 +60,6 @@ stellar-block,                  ipld,           0xd0,           Stellar Block
 stellar-tx,                     ipld,           0xd1,           Stellar Tx
 md4,                            multihash,      0xd4,
 md5,                            multihash,      0xd5,
-bmt,                            multihash,      0xd6,           Binary Merkle Tree Hash
 decred-block,                   ipld,           0xe0,           Decred Block
 decred-tx,                      ipld,           0xe1,           Decred Tx
 ipld-ns,                        namespace,      0xe2,           IPLD path


### PR DESCRIPTION
Hi there,

In light of discussions with ENS maintainers we have decided to abandon the use of `bmt` in favor of using plain `keccak256` multihash codes to identify swarm hashes.

Thanks!