### PR TITLE
Add garlic32, describe garlic addresses

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -86,8 +86,8 @@ ipfs,                           multiaddr,      0x01A5,         libp2p (deprecat
 https,                          multiaddr,      0x01BB,
 onion,                          multiaddr,      0x01BC,
 onion3,                         multiaddr,      0x01BD,
-garlic64,                       multiaddr,      0x01BE,         I2P base64
-garlic32,                       multiaddr,      0x01BF,         I2P base32
+garlic64,                       multiaddr,      0x01BE,         I2P base64 (raw public key)
+garlic32,                       multiaddr,      0x01BF,         I2P base32 (hashed public key)
 quic,                           multiaddr,      0x01CC,
 ws,                             multiaddr,      0x01DD,
 wss,                            multiaddr,      0x01DE,

--- a/table.csv
+++ b/table.csv
@@ -404,6 +404,9 @@ https,              ,                         0x01BB
 quic,               ,                         0x01CC
 ws,                 ,                         0x01DD
 onion,              ,                         0x01BC
+onion3,             ,                         0x01BD
+garlict,            ,                         0x01CA
+garlicu,            ,                         0x01CB
 p2p-circuit,        ,                         0x0122
 
 archiving formats,,

--- a/table.csv
+++ b/table.csv
@@ -87,7 +87,7 @@ https,                          multiaddr,      0x01BB,
 onion,                          multiaddr,      0x01BC,
 onion3,                         multiaddr,      0x01BD,
 garlic64,                       multiaddr,      0x01BE,         I2P base64 (raw public key)
-garlic32,                       multiaddr,      0x01BF,         I2P base32 (hashed public key)
+garlic32,                       multiaddr,      0x01BF,         I2P base32 (hashed public key or encoded public key/checksum+optional secret)
 quic,                           multiaddr,      0x01CC,
 ws,                             multiaddr,      0x01DD,
 wss,                            multiaddr,      0x01DE,


### PR DESCRIPTION
This goes with the other I2P base32 pull requests, it adds i2p base32 addresses and adds descriptions of what the I2P Addresses are to the table.