### PR TITLE
Add git blob object multihash

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -62,6 +62,7 @@ stellar-tx,                     ipld,           0xd1,           Stellar Tx
 md4,                            multihash,      0xd4,
 md5,                            multihash,      0xd5,
 bmt,                            multihash,      0xd6,           Binary Merkle Tree Hash
+git-sha1,                       multihash,      0xd7,           git blob object hash (based on SHA1)
 decred-block,                   ipld,           0xe0,           Decred Block
 decred-tx,                      ipld,           0xe1,           Decred Tx
 ipld-ns,                        namespace,      0xe2,           IPLD path


### PR DESCRIPTION
The git version control system identifies file contents with object
hashes. The hash is calculated by prepending the character sequence
"blob ", the length in bytes as human readable integer, and a NUL byte
before calculating the SHA-1 hash. There are plans to migrate from SHA1
to SHA256, so the hash name `git-sha1` should indicate the hash
function. In addition to "binary large object" hashes git has hashes for
"commit", "tree", and "tag" object types but these are only of interest
in context of a git repository while git blob object hashes can be used
on arbitrary digital objects.

Example:

    $ echo -n "Merkle–Damgård" | git hash-object -w --stdin
    8c85276d1af7f277e82bbf98ddaf30ff3644bcb1

    $ echo -n "blob 17\0Merkle–Damgård" | shasum
    8c85276d1af7f277e82bbf98ddaf30ff3644bcb1  -

To retrieve objects from a git repository by their hash, use `git cat-file`