### PR TITLE
multicodec: add IPLD codec for libp2p public keys

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -37,6 +37,7 @@ rlp,                            serialization,  0x60,           recursive length
 bencode,                        serialization,  0x63,           bencode
 dag-pb,                         ipld,           0x70,           MerkleDAG protobuf
 dag-cbor,                       ipld,           0x71,           MerkleDAG cbor
+libp2p-key,                     ipld,           0x72,           Libp2p Public Key
 git-raw,                        ipld,           0x78,           Raw Git object
 torrent-info,                   ipld,           0x7b,           Torrent file info field (bencoded)
 torrent-file,                   ipld,           0x7c,           Torrent file (bencoded)


### PR DESCRIPTION
This is specifically for the protobuf-encoded libp2p key format:

```proto
enum KeyType {
	RSA = 0;
	Ed25519 = 1;
	Secp256k1 = 2;
	ECDSA = 3;
}

message PublicKey {
	required KeyType Type = 1;
	required bytes Data = 2;
}
```

Required for converting a peer ID into a CID (for base32-encoded IPNS).

fixes #130