### PR TITLE
Add Ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This ["first come, first assign"](https://github.com/multiformats/multicodec/pul
 - [Haskell](https://github.com/multiformats/haskell-multicodec)
 - [Elixir](https://github.com/nocursor/ex-multicodec)
 - [Scala](https://github.com/fluency03/scala-multicodec)
+- [Ruby](https://github.com/sleeplessbyte/ruby-multicodec)
 - [Add yours today!](https://github.com/multiformats/multicodec/edit/master/table.csv)
 
 ## Multicodec Path, also known as [`multistream`](https://github.com/multiformats/multistream)


### PR DESCRIPTION
I've implemented this as proposed in #134, which means that the ruby implementation is just that: a table with some convenience. Currently it would be up to the ruby versions of cid (wip) and outdated ruby multihash to use these tables and add/intepret the prefixes.