### PR TITLE
Add ZeroNet site address

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -74,7 +74,6 @@ dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
 swarm-manifest,                 ipld,           0xfa,           Swarm Manifest
 swarm-feed,                     ipld,           0xfb,           Swarm Feed
-zeronet,                        multiaddr,      0x1000,         ZeroNet site address (old-style Bitcoin address)
 udp,                            multiaddr,      0x0111,
 p2p-webrtc-star,                multiaddr,      0x0113,
 p2p-webrtc-direct,              multiaddr,      0x0114,
@@ -96,6 +95,7 @@ ws,                             multiaddr,      0x01dd,
 wss,                            multiaddr,      0x01de,
 p2p-websocket-star,             multiaddr,      0x01df,
 http,                           multiaddr,      0x01e0,
+zeronet,                        namespace,      0x1000,         ZeroNet site address
 x11,                            multihash,      0x1100,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,

--- a/table.csv
+++ b/table.csv
@@ -69,6 +69,7 @@ ipld-ns,                        namespace,      0xe2,           IPLD path
 ipfs-ns,                        namespace,      0xe3,           IPFS path
 swarm-ns,                       namespace,      0xe4,           Swarm path
 ipns-ns,                        namespace,      0xe5,           IPNS path
+zeronet,                        namespace,      0xe6,           ZeroNet site address
 ed25519-pub,                    key,            0xed,           Ed25519 public key
 dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
@@ -97,7 +98,6 @@ p2p-websocket-star,             multiaddr,      0x01df,
 http,                           multiaddr,      0x01e0,
 json,                           serialization,  0x0200,         JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         MessagePack
-zeronet,                        namespace,      0x1000,         ZeroNet site address
 x11,                            multihash,      0x1100,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,

--- a/table.csv
+++ b/table.csv
@@ -74,6 +74,7 @@ dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
 swarm-manifest,                 ipld,           0xfa,           Swarm Manifest
 swarm-feed,                     ipld,           0xfb,           Swarm Feed
+zeronet,                        multiaddr,      0x1000,         ZeroNet site address (old-style Bitcoin address)
 udp,                            multiaddr,      0x0111,
 p2p-webrtc-star,                multiaddr,      0x0113,
 p2p-webrtc-direct,              multiaddr,      0x0114,


### PR DESCRIPTION
Add [ZeroNet](https://zeronet.io/) site address to protocol codes. ZeroNet uses old-style Bitcoin addresses as site addresses.