### PR TITLE
add a TLS multicodec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -91,6 +91,7 @@ onion,                          multiaddr,      0x01bc,
 onion3,                         multiaddr,      0x01bd,
 garlic64,                       multiaddr,      0x01be,         I2P base64 (raw public key)
 garlic32,                       multiaddr,      0x01bf,         I2P base32 (hashed public key or encoded public key/checksum+optional secret)
+tls,                            multiaddr,      0x01c0,
 quic,                           multiaddr,      0x01cc,
 ws,                             multiaddr,      0x01dd,
 wss,                            multiaddr,      0x01de,


### PR DESCRIPTION
Alternatively, we could repurpose https (443) as TLS and define HTTPS to be `/tls/http` (which is, IMO, more correct).

But let's make this decision quickly. I'm fine keeping this as it is and later deprecating `/https` in favor of `/tls/http`.