### PR TITLE
Add entry for BLAKE3 with 256-bit output (default)

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -15,6 +15,7 @@ keccak-224,                     multihash,      0x1a,           keccak has varia
 keccak-256,                     multihash,      0x1b,
 keccak-384,                     multihash,      0x1c,
 keccak-512,                     multihash,      0x1d,
+blake3,                         multihash,      0x1e,           BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
 dccp,                           multiaddr,      0x21,
 murmur3-128,                    multihash,      0x22,
 murmur3-32,                     multihash,      0x23,
@@ -99,7 +100,6 @@ p2p-websocket-star,             multiaddr,      0x01df,
 http,                           multiaddr,      0x01e0,
 json,                           serialization,  0x0200,         JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         MessagePack
-blake3,                         multihash,      0x0202,         BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes

--- a/table.csv
+++ b/table.csv
@@ -197,6 +197,7 @@ blake2s-232,                    multihash,      0xb25d,
 blake2s-240,                    multihash,      0xb25e,
 blake2s-248,                    multihash,      0xb25f,
 blake2s-256,                    multihash,      0xb260,
+blake3-256,                     multihash,      0xb261,         BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
 skein256-8,                     multihash,      0xb301,         Skein256 consists of 32 output lengths that give different hashes
 skein256-16,                    multihash,      0xb302,
 skein256-24,                    multihash,      0xb303,

--- a/table.csv
+++ b/table.csv
@@ -99,6 +99,7 @@ p2p-websocket-star,             multiaddr,      0x01df,
 http,                           multiaddr,      0x01e0,
 json,                           serialization,  0x0200,         JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         MessagePack
+blake3,                         multihash,      0x0202,         BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes
@@ -197,7 +198,6 @@ blake2s-232,                    multihash,      0xb25d,
 blake2s-240,                    multihash,      0xb25e,
 blake2s-248,                    multihash,      0xb25f,
 blake2s-256,                    multihash,      0xb260,
-blake3-256,                     multihash,      0xb261,         BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
 skein256-8,                     multihash,      0xb301,         Skein256 consists of 32 output lengths that give different hashes
 skein256-16,                    multihash,      0xb302,
 skein256-24,                    multihash,      0xb303,


### PR DESCRIPTION
BLAKE3 is a fast cryptographic hash function. It is only one algorithm with no variants. See https://github.com/BLAKE3-team/BLAKE3 for details.