### PR TITLE
Remove out of date "sortable table" of prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Multicodec is used in various [Multiformats](https://github.com/multiformats/mul
 
 ## Multicodec table
 
-Find the canonical table of multicodecs at [table.csv](/table.csv). There's also a sortable [viewer](https://ipfs.io/ipfs/QmXec1jjwzxWJoNbxQF5KffL8q6hFXm9QwUGaa3wKGk6dT/#title=Multicodecs&src=https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv).
+Find the canonical table of multicodecs at [table.csv](/table.csv).
 
 ### Adding new multicodecs to the table
 


### PR DESCRIPTION
The linked table at https://ipfs.io/ipfs/QmXec1jjwzxWJoNbxQF5KffL8q6hFXm9QwUGaa3wKGk6dT is badly out of date and confused me for a good 15 minutes before I realized what was up. The normal table works fine, so let's just remove the outdated link.