### PR TITLE
add 0x0301: libp2p-peer-record mapping.

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -100,6 +100,7 @@ p2p-websocket-star,             multiaddr,      0x01df,
 http,                           multiaddr,      0x01e0,
 json,                           serialization,  0x0200,         JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         MessagePack
+libp2p-peer-record,             libp2p,         0x0301,         libp2p peer record type
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes


### PR DESCRIPTION
It would be great to have the ability to reserve ranges in this table. I'd like to reserve the `[0x0300,0x03ff]` range for libp2p.

In the context of https://github.com/libp2p/go-libp2p/issues/776.