### PR TITLE
add support for secp256k1-pub

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -71,6 +71,7 @@ ipfs-ns,                        namespace,      0xe3,           IPFS path
 swarm-ns,                       namespace,      0xe4,           Swarm path
 ipns-ns,                        namespace,      0xe5,           IPNS path
 zeronet,                        namespace,      0xe6,           ZeroNet site address
+secp256k1-pub,                  key,            0xe7,           Secp256k1 public key
 ed25519-pub,                    key,            0xed,           Ed25519 public key
 dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx


### PR DESCRIPTION
The decentralized identity community is using DIDs as their foundation layer, i.e., implementing a decentralized PKI system. did:key is one specific DID method and is using multibase/multicodec to express the method-specific-identifier of their DIDs. Currently, there is only support for ed25519-pub but the DID community uses secp256k1 also extensively. In order to use secp256k1 with did:key, we need to get support for secp256k1-pub. 