### PR TITLE
add sha2-256-trunc2 multihash: 0x1012

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -107,6 +107,7 @@ http,                           multiaddr,      0x01e0,
 json,                           serialization,  0x0200,         JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         libp2p peer record type
+sha2-256-trunc254-padded,       multihash,      0x1012,         SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes


### PR DESCRIPTION
SHA2-256 with the trailing 2 bits zeroed out. Primary current use is Filecoin.

It's only "truncated" in the sense that the output is truncated, but there are the same number of output bits.

`0x1012` was chosen to mirror the `0x12` sha2-256 entry and it's close to some other, less common, hash functions.

Current implementations:

* https://github.com/filecoin-project/rust-fil-proofs/blob/ac49ce4111f0bbbb6bec3d6cc2d58d60c48487dd/storage-proofs/core/src/hasher/sha256.rs#L74-L79
* https://github.com/rvagg/js-fil-utils/blob/52255d1603ac49d912d8a1ede66bab5c0baa228b/merkle.js#L5-L12

Ref: https://github.com/multiformats/multicodec/pull/161