### PR TITLE
Add two Poseidon Filecoin variant multihashes

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -430,6 +430,8 @@ skein1024-1000,                 multihash,      0xb3dd,
 skein1024-1008,                 multihash,      0xb3de,
 skein1024-1016,                 multihash,      0xb3df,
 skein1024-1024,                 multihash,      0xb3e0,
+poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
+poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
 holochain-adr-v0,               holochain,      0x807124,       Holochain v0 address    + 8 R-S (63 x Base-32)
 holochain-adr-v1,               holochain,      0x817124,       Holochain v1 address    + 8 R-S (63 x Base-32)
 holochain-key-v0,               holochain,      0x947124,       Holochain v0 public key + 8 R-S (63 x Base-32)


### PR DESCRIPTION
Reserving the 0xb400 range for Poseidon variants. These entries allow FIL to iterate on the `fcX` extension of the name where they stay with BLS12-381 and arity=2. High security variant is for extra circuits that are usable in case new attacks arise from the standard variant.

* The primary ways of differentiating Poseidon implementations are curve and arity, hence their encoding in the name.
* There are additional parameters, hence the need for an extra differentiator `fc1`.
* Filecoin may change these additional parameters in future versions, and therefore need to differentiate and iterate on the `fcX` extension.
* When parameters are initially generated, extra circuits may also be generated, providing a high security, but more costly, variant at the same time. Hence the `sc` addition. This may or may not be used, but will exist alongside the standard variant and be deployable if new attacks render the standard variant less secure.

Implementation: https://github.com/filecoin-project/neptune

Ref: https://github.com/multiformats/multicodec/pull/161
Ref: https://eprint.iacr.org/2019/458.pdf

R= @vmx @mikeal @dignifiedquire @porcuquine @Stebalien