### PR TITLE
Add ripemd definitions

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -32,7 +32,6 @@ dns6,                           multiaddr,      0x37,
 dnsaddr,                        multiaddr,      0x38,
 protobuf,                       serialization,  0x50,           Protocol Buffers
 cbor,                           serialization,  0x51,           CBOR
-ripemd-160,                     multihash,      0x52,
 raw,                            ipld,           0x55,           raw binary
 dbl-sha2-256,                   multihash,      0x56,
 rlp,                            serialization,  0x60,           recursive length prefix
@@ -110,8 +109,9 @@ messagepack,                    serialization,  0x0201,         MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         libp2p peer record type
 sha2-256-trunc254-padded,       multihash,      0x1012,         SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 ripemd-128,                     multihash,      0x1052,
-ripemd-256,                     multihash,      0x1053,
-ripemd-320,                     multihash,      0x1054,
+ripemd-160,                     multihash,      0x1053,
+ripemd-256,                     multihash,      0x1054,
+ripemd-320,                     multihash,      0x1055,
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes

--- a/table.csv
+++ b/table.csv
@@ -32,6 +32,7 @@ dns6,                           multiaddr,      0x37,
 dnsaddr,                        multiaddr,      0x38,
 protobuf,                       serialization,  0x50,           Protocol Buffers
 cbor,                           serialization,  0x51,           CBOR
+ripemd-160,                     multihash,      0x52,
 raw,                            ipld,           0x55,           raw binary
 dbl-sha2-256,                   multihash,      0x56,
 rlp,                            serialization,  0x60,           recursive length prefix
@@ -108,6 +109,9 @@ json,                           serialization,  0x0200,         JSON (UTF-8-enco
 messagepack,                    serialization,  0x0201,         MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         libp2p peer record type
 sha2-256-trunc254-padded,       multihash,      0x1012,         SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
+ripemd-128,                     multihash,      0x1052,
+ripemd-256,                     multihash,      0x1053,
+ripemd-320,                     multihash,      0x1054,
 x11,                            multihash,      0x1100,
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes


### PR DESCRIPTION
As proposed in #117, there are no definitions for the ripemd family of hashes.

The previous PR would have been sufficient with the given feedback, but the author never made the requested changes and the PR is now over a year old.

This PR would replace #117.

It conforms to feedback on #117, with the more common ripemd-160 hash using the one byte space and the less common algorithms using the two byte space.

0x52 was chosen somewhat arbitrarily as the ASCII encoding of 'R'.

Furthermore, 0x51 is the serialization code for CBOR, which means 0x52 is unlikely to be needed as a value in relation to CBOR.