### PR TITLE
Add Bitcoin Witness Commitment (0xb2)

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -59,6 +59,7 @@ eth-account-snapshot,           ipld,           0x97,           Ethereum Account
 eth-storage-trie,               ipld,           0x98,           Ethereum Contract Storage Trie (Eth-Secure-Trie)
 bitcoin-block,                  ipld,           0xb0,           Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           Bitcoin Tx
+bitcoin-witness-commitment,     ipld,           0xb2,           Bitcoin Witness Commitment
 zcash-block,                    ipld,           0xc0,           Zcash Block
 zcash-tx,                       ipld,           0xc1,           Zcash Tx
 stellar-block,                  ipld,           0xd0,           Stellar Block


### PR DESCRIPTION
This completes the set needed to interact with the full Bitcoin graph with IPLD. The Witness Commitment is the link to the second binary merkle that contains the transactions with full witness data, whereas the initial binary merkle pointed to from the block header (known as `merkleroot`) points to the transactions without witness data. Since SegWit, this second binary merkle tree gets linked to from the coinbase `scriptPubKey` property and the coinbase is excluded from the binary merkle (replaced with `0x000...000`) as a result. The reason we need this new element is that the coinbase points to an intermediate structure which concatenates a nonce and the new `merkleroot` together and the nonce, in the standard representation, becomes the "witness" property of the coinbase itself. So to reconstruct the original full block graph structure you have to navigate to the transactions in the witness merkle and on the way pick up this nonce to re-attach it to the coinbase. This Witness Commitment is 64-bytes long and otherwise looks like a node in the normal binary merkle, but the leftmost side is the nonce (which happens to be `0x000...000` on most blocks because Bitcoin Core does that, but other miners are allowed to insert random strings here and there are so far ~4000 of these in the blockchain).

Decoding a `bitcoin-witness-commitment` yields a:

```
type WitnessCommitment struct {
  merkleRoot &MaybeTransaction
  nonce Bytes # 32-bytes long
}
```

Where a `MaybeTransaction` is a union that could be an actual transaction or a node in a binary merkle tree, which are also 64-bytes long but look like this:

```
type TransactionMerkleNode [&MaybeTransaction] # strictly 2 elements long
```

Another notable problem that makes a dedicated codec for this helpful is that there are pre-SegWit blocks with a coinbase `scriptPubKey` that _look_ like they point to a witness commitment and there's no firm way to determine whether it is one or not unless you try to load it (from wherever these blocks are coming from). A failure to load an `0xb2` can be a signal that the presumed witness commitment is actually not a witness commitment. A failure to load anything else can be firmly interpreted as a failure to locate something that _should_ exist.

This is implemented and in use in the code @ https://github.com/ipld/js-ipld-bitcoin/pull/63 (will likely be made into a separate repo for `@ipld/bitcoin` with the js-ipld-bitcoin repo being the k