### PR TITLE
Add 0xcert asset imprints

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -437,6 +437,7 @@ skein1024-1016,                 multihash,      0xb3df,
 skein1024-1024,                 multihash,      0xb3e0,
 poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
 poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
+0xcert-imprint-256,             0xcert,         0xce11,         0xcert Asset Imprint (root hash)
 fil-commitment-unsealed,        filecoin,       0xf101,         Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)
 holochain-adr-v0,               holochain,      0x807124,       Holochain v0 address    + 8 R-S (63 x Base-32)


### PR DESCRIPTION
Adds an additional well-known format to the table.

0xcert Asset Imprints. This is a Merkle tree structure which is used to hash and identify arbitrary-depth objects (generally from JSON). This is an open specification.

Following is some documentation for reference and your consideration of this pull request:

- Overview: https://github.com/0xcert/framework/blob/master/packages/0xcert-cert/README.md
- Documentation: https://docs.0xcert.org/api/guides/update-asset-imprint.html#usage-overview
- Reference implementation: https://github.com/0xcert/framework/tree/master/packages/0xcert-cert