### PR TITLE
Add Cap'n Proto  serialization format

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -32,6 +32,7 @@ dns6,                           multiaddr,      0x37,
 dnsaddr,                        multiaddr,      0x38,
 protobuf,                       serialization,  0x50,           Protocol Buffers
 cbor,                           serialization,  0x51,           CBOR
+capnproto,                      serialization,  0x52,           Cap'n Proto (capnproto.org)
 raw,                            ipld,           0x55,           raw binary
 dbl-sha2-256,                   multihash,      0x56,
 rlp,                            serialization,  0x60,           recursive length prefix


### PR DESCRIPTION
This PR adds the [Cap'n Proto](https://capnproto.org/) serialization & RPC wire format.

I move to include this in the sub-`0x80` range because of the widespread popularity and usage of the format, as evidenced by:

- 7.5k stars on GitHub for the [reference implementation](https://github.com/capnproto/capnproto)
- Implementation of the spec in [15+ languages](https://capnproto.org/otherlang.html)
- Consistent, active development of:
  - the official spec
  - the reference implementation 
  - language-specific implementations

