### PR TITLE
Naming restrictions (doc & validate), rename `0xcert` to be code-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This ["first come, first assign"](https://github.com/multiformats/multicodec/pul
 
 The first 127 bits are encoded as a single-byte varint, hence they are reserved for the most widely used multicodecs. So if you are adding your own codec to the table, you most likely would want to ask for a codec bigger than `0x80`.
 
+Codec names should be easily convertible to constants in common programming languages using basic transformation rules (e.g. upper-case, conversion of `-` to `_`, etc.). Therefore they should contain alphanumeric characters, with the first character being alphabetic. The primary delimiter for multi-part names should be `-`, with `_` reserved for cases where a secondary delimiter is required. For example: `bls12_381-g1-pub` contains 3 parts: `bls_381`, `g1` and `pub`, where `bls_381` is "BLS 381" which is not commonly written as "BLS381" and therefore requires a secondary separator.
+
+The `validate.py` script can be used to validate the table once it's edited.
+
 ## Implementations
 
 - [go](https://github.com/multiformats/go-multicodec/)

--- a/table.csv
+++ b/table.csv
@@ -437,7 +437,7 @@ skein1024-1016,                 multihash,      0xb3df,
 skein1024-1024,                 multihash,      0xb3e0,
 poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
 poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
-0xcert-imprint-256,             0xcert,         0xce11,         0xcert Asset Imprint (root hash)
+zeroxcert-imprint-256,          zeroxcert,      0xce11,         0xcert Asset Imprint (root hash)
 fil-commitment-unsealed,        filecoin,       0xf101,         Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)
 holochain-adr-v0,               holochain,      0x807124,       Holochain v0 address    + 8 R-S (63 x Base-32)

--- a/validate.py
+++ b/validate.py
@@ -43,6 +43,10 @@ def check(fname='table.csv'):
                 if not re.match(r"^0x([0-9a-f][0-9a-f])+$", code):
                     raise CheckError(f"code for '{name}' does not look like a byte sequence: '{code}'")
 
+                # Check name format
+                if not re.match(r"^[a-z][a-z0-9_-]+$", name):
+                    raise CheckError(f"name '{name}' violates naming restrictions")
+
                 # Parse the code
                 try:
                     code = int(code, 16)


### PR DESCRIPTION
Ref: https://github.com/multiformats/multicodec/issues/181
Ref: https://github.com/multiformats/multicodec/pull/177

/cc @bonedaddy @fulldecent 

I agree with @bonedaddy on this one, it's awkward for `0xcert` but they kind of chose an intentionally awkward name, I bet their code has issues with constant naming.

@fulldecent can you live with this rename or does this violate something fundamental about `0xcert`?