### PR TITLE
Add ENS Namehash

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -57,6 +57,7 @@ eth-tx-receipt,                 ipld,           0x95,           Ethereum Transac
 eth-state-trie,                 ipld,           0x96,           Ethereum State Trie (Eth-Secure-Trie)
 eth-account-snapshot,           ipld,           0x97,           Ethereum Account Snapshot (RLP)
 eth-storage-trie,               ipld,           0x98,           Ethereum Contract Storage Trie (Eth-Secure-Trie)
+eth-ens-namehash,               ipld,           0x99,           Ethereum Name Service (Namehash)
 bitcoin-block,                  ipld,           0xb0,           Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           Bitcoin Witness Commitment


### PR DESCRIPTION
Adding ENS Namehash at 0x99 in table.csv

> eth-ens-namehash, ipld, 0x99, Ethereum Name Service (Namehash)

base32 - cidv1 - dag-pb - eth-ens-namehash-256 - de9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f
`ipns://foo.eth` as namehash CID `ipns://bafyjsaja32nqt7l4l6ib4i5d6gp6zrkifdu4qscttaa6qzmrxwmadmaz7bhq`.

Ref : ethereum/EIPs/issues/137 
ENS labels are normalized as UTS46 with the options `transitional=false` and `useSTD3AsciiRules=true` (https://www.npmjs.com/package/eth-ens-namehash)