### PR TITLE
Add BLS 12-381 g1 and g2 public key concatenated identifier

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -79,6 +79,7 @@ bls12_381-g1-pub,               key,            0xea,           BLS12-381 public
 bls12_381-g2-pub,               key,            0xeb,           BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           Curve25519 public key
 ed25519-pub,                    key,            0xed,           Ed25519 public key
+bls12_381-g1g2-pub,             key,            0xee,           BLS12-381 concatenated public keys in both the G1 and G2 fields
 dash-block,                     ipld,           0xf0,           Dash Block
 dash-tx,                        ipld,           0xf1,           Dash Tx
 swarm-manifest,                 ipld,           0xfa,           Swarm Manifest


### PR DESCRIPTION
For certain signatures such as https://github.com/mattrglobal/bbs-signatures it is useful to have a single private key have a corresponding public key in both the G1 and G2 fields.