### PR TITLE
Define CIDv1 as a mutlicodec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -1,6 +1,8 @@
 name,                           tag,            code,           description
 identity,                       multihash,      0x00,           raw binary
 cidv1,                          ipld,           0x01,           CIDv1
+cidv2,                          ipld,           0x02,           CIDv2
+cidv3,                          ipld,           0x03,           CIDv3
 ip4,                            multiaddr,      0x04,
 tcp,                            multiaddr,      0x06,
 sha1,                           multihash,      0x11,

--- a/table.csv
+++ b/table.csv
@@ -1,5 +1,6 @@
 name,                           tag,            code,           description
 identity,                       multihash,      0x00,           raw binary
+cidv1,                          ipld,           0x01,           CIDv1
 ip4,                            multiaddr,      0x04,
 tcp,                            multiaddr,      0x06,
 sha1,                           multihash,      0x11,


### PR DESCRIPTION
This PR adds CIDv1 as a multicodec with value `0x01`. 

Fixes https://github.com/multiformats/multicodec/issues/49