### PR TITLE
Add Ceramic Document Id

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -65,6 +65,7 @@ bitcoin-tx,                     ipld,           0xb1,           Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           Bitcoin Witness Commitment
 zcash-block,                    ipld,           0xc0,           Zcash Block
 zcash-tx,                       ipld,           0xc1,           Zcash Tx
+docid,                          namespace,      0xce,           Ceramic Document Id
 stellar-block,                  ipld,           0xd0,           Stellar Block
 stellar-tx,                     ipld,           0xd1,           Stellar Tx
 md4,                            multihash,      0xd4,


### PR DESCRIPTION
Adds an entry for Ceramic Document Ids, as `0xce`. I think this would be a `namespace`, but let me know if it should be something different!

See how it's used: https://github.com/ceramicnetwork/CIP/issues/59