### PR TITLE
Add RSA public key (x.509 Encoded)

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -37,6 +37,7 @@ protobuf,                       serialization,  0x50,           Protocol Buffers
 cbor,                           serialization,  0x51,           CBOR
 raw,                            ipld,           0x55,           raw binary
 dbl-sha2-256,                   multihash,      0x56,
+rsa-pub,                        key,            0x5d,           RSA public key (X.509 encoded)
 rlp,                            serialization,  0x60,           recursive length prefix
 bencode,                        serialization,  0x63,           bencode
 dag-pb,                         ipld,           0x70,           MerkleDAG protobuf


### PR DESCRIPTION
Add a prefix for raw (_not_ libp2p) x.509 public key bytes. I think we should have this for a parity with other public key formats.

It's worth adding _now_ because it'll make writing code that does key rotation from RSA -> ED25519 with open standards possible.

Regarding the `0x5d` prefix There's a W3C working group [draft spec](https://github.com/w3c-ccg/did-method-key) floating out in the wild that would require this addition to make RSA keys work, and [this issue](https://github.com/w3c-ccg/lds-ed25519-2018/issues/3) makes reference to `0x5d` as the chosen prefix. I've reused this value here to be just slightly above picking at random.