### PR TITLE
Add Skynet codecs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -458,3 +458,4 @@ holochain-key-v0,               holochain,      0x947124,       Holochain v0 pub
 holochain-key-v1,               holochain,      0x957124,       Holochain v1 public key + 8 R-S (63 x Base-32)
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
+skynet-skylink-v1,              skynet,         0xd101,         Skynet v1 skylink (Base64) 

--- a/table.csv
+++ b/table.csv
@@ -458,5 +458,6 @@ holochain-key-v0,               holochain,      0x947124,       Holochain v0 pub
 holochain-key-v1,               holochain,      0x957124,       Holochain v1 public key + 8 R-S (63 x Base-32)
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
-skynet-ns,                      namespace,      0xd101,         Skynet Namespace
-skynet-skylink-v1,              skynet,         0xd102,         Skynet v1 skylink (Base64)
+sia-ns,                         namespace,      0x1991,         Sia Namespace
+skynet-ns,                      namespace,      0x1992,         Skynet Namespace
+skynet-skylink-v1,              skynet,         0x1993,         Skynet v1 skylink (Base64)

--- a/table.csv
+++ b/table.csv
@@ -458,6 +458,5 @@ holochain-key-v0,               holochain,      0x947124,       Holochain v0 pub
 holochain-key-v1,               holochain,      0x957124,       Holochain v1 public key + 8 R-S (63 x Base-32)
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
-sia-ns,                         namespace,      0x1991,         Sia Namespace
-skynet-ns,                      namespace,      0x1992,         Skynet Namespace
-skynet-skylink-v1,              skynet,         0x1993,         Skynet v1 skylink (Base64)
+skynet-ns,                      namespace,      0xb19910,         Skynet Namespace
+skynet-skylink-v1,              skynet,         0xb19911,         Skynet v1 skylink (Base64)

--- a/table.csv
+++ b/table.csv
@@ -458,4 +458,4 @@ holochain-key-v0,               holochain,      0x947124,       Holochain v0 pub
 holochain-key-v1,               holochain,      0x957124,       Holochain v1 public key + 8 R-S (63 x Base-32)
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
-skynet-ns,                      namespace,      0xb19910,         Skynet Namespace
+skynet-ns,                      namespace,      0xb19910,       Skynet Namespace

--- a/table.csv
+++ b/table.csv
@@ -459,4 +459,3 @@ holochain-key-v1,               holochain,      0x957124,       Holochain v1 pub
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
 skynet-ns,                      namespace,      0xb19910,         Skynet Namespace
-skynet-skylink-v1,              skynet,         0xb19911,         Skynet v1 skylink (Base64)

--- a/table.csv
+++ b/table.csv
@@ -458,4 +458,5 @@ holochain-key-v0,               holochain,      0x947124,       Holochain v0 pub
 holochain-key-v1,               holochain,      0x957124,       Holochain v1 public key + 8 R-S (63 x Base-32)
 holochain-sig-v0,               holochain,      0xa27124,       Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       Holochain v1 signature  + 8 R-S (63 x Base-32)
-skynet-skylink-v1,              skynet,         0xd101,         Skynet v1 skylink (Base64) 
+skynet-ns,                      namespace,      0xd101,         Skynet Namespace
+skynet-skylink-v1,              skynet,         0xd102,         Skynet v1 skylink (Base64)


### PR DESCRIPTION
This PR adds a Skynet codec to ultimately add ENS support for Skylinks.  
Skynet is a decentralized CDN built on top of the Sia network, find out more [here](https://siasky.net/).