### PR TITLE
feat: add aes cipher multicodecs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -125,6 +125,9 @@ p521-pub,                       key,            0x1202,         P-521 public Key
 ed448-pub,                      key,            0x1203,         Ed448 public Key
 x448-pub,                       key,            0x1204,         X448 public Key
 ed25519-priv,                   key,            0x1300,         Ed25519 private key
+aes-gcm                         cipher,         0x1400,         AES-GCM
+aes-cbc                         cipher,         0x1401,         AES-CBC
+aes-ctr                         cipher,         0x1402,         AES-CTR
 kangarootwelve,                 multihash,      0x1d01,         KangarooTwelve is an extendable-output hash function based on Keccak-p
 sm3-256,                        multihash,      0x534d,
 blake2b-8,                      multihash,      0xb201,         Blake2b consists of 64 output lengths that give different hashes


### PR DESCRIPTION
Followup from today’s IPLD call.

Working on an implementation of block encryption and I need to assign multicodecs for the main AES ciphers.

I think this is a good range to start adding ciphers in but if anyone has a better idea I’m open to it.