### PR TITLE
Add missing variations of sha2

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -19,9 +19,13 @@ keccak-256,                     multihash,      0x1b,
 keccak-384,                     multihash,      0x1c,
 keccak-512,                     multihash,      0x1d,
 blake3,                         multihash,      0x1e,           BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
+sha2-224,                       multihash,      0x1f,           aka SHA-224; specified by FIPS 180-4.
+sha2-384,                       multihash,      0x20,           aka SHA-384; specified by FIPS 180-4.
 dccp,                           multiaddr,      0x21,
 murmur3-128,                    multihash,      0x22,
 murmur3-32,                     multihash,      0x23,
+sha2-512-224,                   multihash,      0x24,           aka SHA-512/224; specified by FIPS 180-4.
+sha2-512-256,                   multihash,      0x25,           aka SHA-512/256; specified by FIPS 180-4.
 ip6,                            multiaddr,      0x29,
 ip6zone,                        multiaddr,      0x2a,
 path,                           namespace,      0x2f,           Namespace for string paths. Corresponds to `/` in ASCII.


### PR DESCRIPTION
Per discussion in https://github.com/multiformats/multicodec/issues/205 .

I've inserted these entries at the first available numbers following the other sha2 variants.  It's unfortunate we can't put them all in a row, but no space is available since some sha3 variants immediately follow the already-entabled sha2 variants.