### PR TITLE
Add SoftWare Heritage persistent IDentifier snapshots

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -115,6 +115,7 @@ ws,                             multiaddr,      0x01dd,         permanent,
 wss,                            multiaddr,      0x01de,         permanent,
 p2p-websocket-star,             multiaddr,      0x01df,         permanent,
 http,                           multiaddr,      0x01e0,         draft,
+swhid-1-snp,                    ipld,           0x01f0,         draft,     SoftWare Heritage persistent IDentifier version 1 snapshot
 json,                           serialization,  0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type


### PR DESCRIPTION
See
https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
for the technical details of that spec.

Software Heritage has done a superb job promoting content addressing in
general, and their identifier scheme (SWHIDs, for short) in particular.
By supporting them in CIDs / IPLD, I hope the IPFS ecosystem can align
itself with that effort.

Per the linked documentation, SWHIDs have their own nested grammar and
versioning scheme. I begun by taking the version 1 core identifier
grammar, unrolled it, and replaced `:` with `-` per the guidelines on
separators, with the result being these 5 rows.

There is overlap between the remaining for and git-raw, so this just
adds SWHID snapshots for now.