### PR TITLE
Add secp256k1 private key

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -79,6 +79,7 @@ swarm-ns,                       namespace,      0xe4,           draft,     Swarm
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
 secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key
+secp256k1-priv,                 key,            0xe8,           draft,     Secp256k1 private key
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key

--- a/table.csv
+++ b/table.csv
@@ -79,7 +79,7 @@ swarm-ns,                       namespace,      0xe4,           draft,     Swarm
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
 secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key
-secp256k1-priv,                 key,            0x1301,           draft,     Secp256k1 private key
+secp256k1-priv,                 key,            0x1301,         draft,     Secp256k1 private key
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key

--- a/table.csv
+++ b/table.csv
@@ -79,7 +79,7 @@ swarm-ns,                       namespace,      0xe4,           draft,     Swarm
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
 secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key
-secp256k1-priv,                 key,            0xe8,           draft,     Secp256k1 private key
+secp256k1-priv,                 key,            0x1301,           draft,     Secp256k1 private key
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key


### PR DESCRIPTION
Reasoning:

There already exists and ed25519 priv key: https://github.com/multiformats/multicodec/blob/master/table.csv#L128

Without the ability to represent both public and private components of asymmetric key pairs users will be forced for do things like this:

```
'id': '',
'type': 'EcdsaSecp256k1VerificationKey2020',
'controller': 'did:example:123',
'publicKeyMultibase': 'zQ3shU9mxTYfMTLceuppoNM5siowHvw3xBk21r855kwgNHNAX',
'privateKeyBase58': '6GyEn649EsbEEJXGQ5m8Eq6NANDmHTPQPWGyF5uL7kx8'
```

This prevents efficient compression using multibase codecs.

We will likely need to add entries for NIST curves and BLS12381 as well.