### PR TITLE
added kcp just under http

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -111,6 +111,7 @@ ws,                             multiaddr,      0x01dd,         permanent,
 wss,                            multiaddr,      0x01de,         permanent,
 p2p-websocket-star,             multiaddr,      0x01df,         permanent,
 http,                           multiaddr,      0x01e0,         draft,
+kcp,                            multiaddr,      0x01e1,         draft,
 json,                           serialization,  0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type

--- a/table.csv
+++ b/table.csv
@@ -111,7 +111,7 @@ ws,                             multiaddr,      0x01dd,         permanent,
 wss,                            multiaddr,      0x01de,         permanent,
 p2p-websocket-star,             multiaddr,      0x01df,         permanent,
 http,                           multiaddr,      0x01e0,         draft,
-kcp,                            multiaddr,      0x01e1,         draft,
+kcp,                            multiaddr,      0x01e1,         draft, Reliable, Ordered UDP with CFB encryption, Reed Solomon Forward Error Correction, and Connection Multiplexing and automatic tuning
 json,                           serialization,  0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type


### PR DESCRIPTION
Aside from quic there is no other alternative reliable UDP protocols in the list. KCP ( https://github.com/xtaci/kcp-go ) is one of the most mature examples existing and I personally plan to use it in whatever p2p systems I am building in the near future.