### PR TITLE
Clarify public key encodings

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -78,7 +78,7 @@ ipfs-ns,                        namespace,      0xe3,           draft,     IPFS 
 swarm-ns,                       namespace,      0xe4,           draft,     Swarm path
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
-secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key
+secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key (compressed)
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key
@@ -120,9 +120,9 @@ ripemd-160,                     multihash,      0x1053,         draft,
 ripemd-256,                     multihash,      0x1054,         draft,
 ripemd-320,                     multihash,      0x1055,         draft,
 x11,                            multihash,      0x1100,         draft,
-p256-pub,                       key,            0x1200,         draft,     P-256 public Key
-p384-pub,                       key,            0x1201,         draft,     P-384 public Key
-p521-pub,                       key,            0x1202,         draft,     P-521 public Key
+p256-pub,                       key,            0x1200,         draft,     P-256 public Key (compressed)
+p384-pub,                       key,            0x1201,         draft,     P-384 public Key (compressed)
+p521-pub,                       key,            0x1202,         draft,     P-521 public Key (compressed)
 ed448-pub,                      key,            0x1203,         draft,     Ed448 public Key
 x448-pub,                       key,            0x1204,         draft,     X448 public Key
 ed25519-priv,                   key,            0x1300,         draft,     Ed25519 private key


### PR DESCRIPTION
The affected curves can be represented in both a compressed and an uncompressed format. This clarifies that the compressed format should be used.