### PR TITLE
Make TLS permanent

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -106,7 +106,7 @@ onion,                          multiaddr,      0x01bc,         draft,
 onion3,                         multiaddr,      0x01bd,         draft,
 garlic64,                       multiaddr,      0x01be,         draft,     I2P base64 (raw public key)
 garlic32,                       multiaddr,      0x01bf,         draft,     I2P base32 (hashed public key or encoded public key/checksum+optional secret)
-tls,                            multiaddr,      0x01c0,         draft,
+tls,                            multiaddr,      0x01c0,         permanent, Transport Layer Security
 noise,                          multiaddr,      0x01c6,         draft,
 quic,                           multiaddr,      0x01cc,         permanent,
 ws,                             multiaddr,      0x01dd,         permanent,


### PR DESCRIPTION
There are https://github.com/multiformats/go-multiaddr/pull/153 and https://github.com/multiformats/multiaddr/pull/109 PR's that add TLS.

Also, TLS is used in examples in README in the [main repo](https://github.com/multiformats/multiaddr/blame/master/README.md#L121).

Therefore, it seems logical to make it permanent.