### PR TITLE
log and log trie multicodec types

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -51,8 +51,8 @@ leofcoin-pr,                    ipld,           0x83,           draft,     Leofc
 sctp,                           multiaddr,      0x84,           draft,
 dag-jose,                       ipld,           0x85,           draft,     MerkleDAG JOSE
 dag-cose,                       ipld,           0x86,           draft,     MerkleDAG COSE
-eth-header,                     ipld,           0x90,           permanent, Ethereum Header (RLP)
-eth-header-list,                ipld,           0x91,           permanent, Ethereum Header List (RLP)
+eth-block,                      ipld,           0x90,           permanent, Ethereum Header (RLP)
+eth-block-list,                 ipld,           0x91,           permanent, Ethereum Header List (RLP)
 eth-tx-trie,                    ipld,           0x92,           permanent, Ethereum Transaction Trie (Eth-Trie)
 eth-tx,                         ipld,           0x93,           permanent, Ethereum Transaction (MarshalBinary)
 eth-tx-receipt-trie,            ipld,           0x94,           permanent, Ethereum Transaction Receipt Trie (Eth-Trie)

--- a/table.csv
+++ b/table.csv
@@ -51,15 +51,17 @@ leofcoin-pr,                    ipld,           0x83,           draft,     Leofc
 sctp,                           multiaddr,      0x84,           draft,
 dag-jose,                       ipld,           0x85,           draft,     MerkleDAG JOSE
 dag-cose,                       ipld,           0x86,           draft,     MerkleDAG COSE
-eth-block,                      ipld,           0x90,           permanent, Ethereum Block (RLP)
-eth-block-list,                 ipld,           0x91,           permanent, Ethereum Block List (RLP)
+eth-header,                     ipld,           0x90,           permanent, Ethereum Header (RLP)
+eth-header-list,                ipld,           0x91,           permanent, Ethereum Header List (RLP)
 eth-tx-trie,                    ipld,           0x92,           permanent, Ethereum Transaction Trie (Eth-Trie)
-eth-tx,                         ipld,           0x93,           permanent, Ethereum Transaction (RLP)
+eth-tx,                         ipld,           0x93,           permanent, Ethereum Transaction (MarshalBinary)
 eth-tx-receipt-trie,            ipld,           0x94,           permanent, Ethereum Transaction Receipt Trie (Eth-Trie)
-eth-tx-receipt,                 ipld,           0x95,           permanent, Ethereum Transaction Receipt (RLP)
+eth-tx-receipt,                 ipld,           0x95,           permanent, Ethereum Transaction Receipt (MarshalBinary)
 eth-state-trie,                 ipld,           0x96,           permanent, Ethereum State Trie (Eth-Secure-Trie)
 eth-account-snapshot,           ipld,           0x97,           permanent, Ethereum Account Snapshot (RLP)
 eth-storage-trie,               ipld,           0x98,           permanent, Ethereum Contract Storage Trie (Eth-Secure-Trie)
+eth-receipt-log-trie,           ipld,           0x99,           draft,     Ethereum Transaction Receipt Log Trie (Eth-Trie)
+eth-reciept-log,                ipld,           0x9a,           draft,     Ethereum Transaction Receipt Log (RLP)
 bitcoin-block,                  ipld,           0xb0,           permanent, Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           permanent, Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           permanent, Bitcoin Witness Commitment


### PR DESCRIPTION
In our IPLD representation of the Ethereum Merkle data structure, we would like to compose the logs contained in a receipt into a "log trie" that is linked to from the receipt. We want to Merkleize them in a manner analogous to how transaction and receipt lists canonically are: composing them into a Modified Merkle Patricia Trie (MMPT), whereby the RLP encoded log is the value stored in a leaf node and the path to that leaf node is the keccak256 hash of the log's index in the receipt.

We are not changing the binary encoding of a receipt IPLD- that remains the consensus encoding of a receipt- we only want to change the in-memory materialization of that binary data so that a receipt IPLD node links to the root node of a log trie.

Implementations of the new log and log trie codecs and the updated receipt codec can be found [here](https://github.com/vulcanize/go-codec-dageth/pull/27).

The motivation for this is so that
1. We can describe IPLD selectors that extend all the way down to a log node.
2. We can generate (semi) conventional MMPT proofs for individual logs.

The primary issue here, I think, is that it does add additional overhead when unmarshalling receipt binary into an ipld.Node as we need to materialize the trie to calculate its root hash and generate the link. If need be, we can create a custom codec that does this and leave the normal receipt codec as is.

Some unrelated tweaks I threw in, that might be superfluous:
1. Changed `eth-block` to `eth-header`, as it is only the header that is referenced by "block"hash and stored as the IPLD block. The header contains all the links to the uncles, tx, rct, state (and thereby storage) tries but the block body is not a part of the "eth-block" IPLD block.
2. Changed "RLP" to "MarshalBinary" in the descriptions for transaction and receipt, because after EIP-2718 tx envelops were introduced the consensus encoding of a tx or rct is only the pure RLP encoding for the legacy types.