### PR TITLE
Add Arweave Codec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -469,3 +469,4 @@ holochain-key-v1,               holochain,      0x957124,       draft,     Holoc
 holochain-sig-v0,               holochain,      0xa27124,       draft,     Holochain v0 signature  + 8 R-S (63 x Base-32)
 holochain-sig-v1,               holochain,      0xa37124,       draft,     Holochain v1 signature  + 8 R-S (63 x Base-32)
 skynet-ns,                      namespace,      0xb19910,       draft,     Skynet Namespace
+arweave-ns,                     namespace,      0xb29910,       draft,     Arweave Namespace


### PR DESCRIPTION
This PR adds an Arweave codec to ultimately add ENS support for Arweave Hashes.
Arweave is a decentralized CDN network that permanently stores any file on its network, find out more [here](https://www.arweave.org/).