### PR TITLE
Add RSA public key

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -132,6 +132,7 @@ p384-pub,                       key,            0x1201,         draft,     P-384
 p521-pub,                       key,            0x1202,         draft,     P-521 public Key (compressed)
 ed448-pub,                      key,            0x1203,         draft,     Ed448 public Key
 x448-pub,                       key,            0x1204,         draft,     X448 public Key
+rsa-x509-pub,                   key,            0x1205,         draft,     RSA public key (X.509 encoded)
 ed25519-priv,                   key,            0x1300,         draft,     Ed25519 private key
 secp256k1-priv,                 key,            0x1301,         draft,     Secp256k1 private key
 x25519-priv,                    key,            0x1302,         draft,     Curve25519 private key


### PR DESCRIPTION
Add RSA public key. Updated over https://github.com/multiformats/multicodec/pull/195

Changed from #195:
* Move to `0x12XX` range
* Added X.509 directly to the name (happy to take out)

RSA is has length variants, I suppose that we're going to use multiformats to specify key length. Alternately, we could specify rsa-2048-pub, rsa-4096-pub, and so on, but it feels orthogonal _to me_.

Thoughts or changes @b5?