### PR TITLE
Add CARv2 `MultihashIndexSorted` codec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -121,6 +121,7 @@ messagepack,                    serialization,  0x0201,         draft,     Messa
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type
 libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2p relay reservation voucher
 car-index-sorted,               serialization,  0x0400,         draft,     CARv2 IndexSorted index format
+car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 ripemd-128,                     multihash,      0x1052,         draft,
 ripemd-160,                     multihash,      0x1053,         draft,


### PR DESCRIPTION
Define a new codec for CARv2 `MultihashIndexSorted`.

See:
- https://github.com/ipld/go-car/pull/217
- https://github.com/ipld/go-car/issues/214