### PR TITLE
Add AES & ChaCha keys

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -62,6 +62,11 @@ eth-account-snapshot,           ipld,           0x97,           permanent, Ether
 eth-storage-trie,               ipld,           0x98,           permanent, Ethereum Contract Storage Trie (Eth-Secure-Trie)
 eth-receipt-log-trie,           ipld,           0x99,           draft,     Ethereum Transaction Receipt Log Trie (Eth-Trie)
 eth-reciept-log,                ipld,           0x9a,           draft,     Ethereum Transaction Receipt Log (RLP)
+aes-128,                        key,            0xa0,           draft,     128-bit AES symmetric key
+aes-192,                        key,            0xa1,           draft,     192-bit AES symmetric key
+aes-256,                        key,            0xa2,           draft,     256-bit AES symmetric key
+chacha-128,                     key,            0xa3,           draft,     128-bit ChaCha symmetric key
+chacha-256,                     key,            0xa4,           draft,     256-bit ChaCha symmetric key
 bitcoin-block,                  ipld,           0xb0,           permanent, Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           permanent, Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           permanent, Bitcoin Witness Commitment
@@ -139,11 +144,6 @@ secp256k1-priv,                 key,            0x1301,         draft,     Secp2
 x25519-priv,                    key,            0x1302,         draft,     Curve25519 private key
 kangarootwelve,                 multihash,      0x1d01,         draft,     KangarooTwelve is an extendable-output hash function based on Keccak-p
 sm3-256,                        multihash,      0x534d,         draft,
-aes-128,                        key,            0xa0,           draft,     128-bit AES symmetric key
-aes-192,                        key,            0xa1,           draft,     192-bit AES symmetric key
-aes-256,                        key,            0xa2,           draft,     256-bit AES symmetric key
-chacha-128,                     key,            0xa3,           draft,     128-bit ChaCha symmetric key
-chacha-256,                     key,            0xa4,           draft,     256-bit ChaCha symmetric key
 blake2b-8,                      multihash,      0xb201,         draft,     Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,         draft,
 blake2b-24,                     multihash,      0xb203,         draft,

--- a/table.csv
+++ b/table.csv
@@ -139,6 +139,11 @@ secp256k1-priv,                 key,            0x1301,         draft,     Secp2
 x25519-priv,                    key,            0x1302,         draft,     Curve25519 private key
 kangarootwelve,                 multihash,      0x1d01,         draft,     KangarooTwelve is an extendable-output hash function based on Keccak-p
 sm3-256,                        multihash,      0x534d,         draft,
+aes-128,                        key,            0xa0,           draft,     128-bit AES symmetric key
+aes-192,                        key,            0xa1,           draft,     192-bit AES symmetric key
+aes-256,                        key,            0xa2,           draft,     256-bit AES symmetric key
+chacha-128,                     key,            0xa3,           draft,     128-bit ChaCha symmetric key
+chacha-256,                     key,            0xa4,           draft,     256-bit ChaCha symmetric key
 blake2b-8,                      multihash,      0xb201,         draft,     Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,         draft,
 blake2b-24,                     multihash,      0xb203,         draft,


### PR DESCRIPTION
Add common symmetric keys. We have a use case for storing & (securely) transmitting symmetric keys to encrypted data on IPFS.

# Why No Operation Modes?
I didn't split out `-CBC`, `CTR`, `-GCM`, and so on because those are modes of operation, not the actual keys. AFAICT this also extends to XChaCha, which only accepts 256-bit keys but the contents of that 256-bit key is the same. We _can_ add the operation modes to the format, but _to me_ that feels like it belongs on the encrypted data, not on the key.

# Why Separate Keys Types?
If we take the reasoning above to the extreme These are all random bits. In theory we could just have "256-bit symmetric key". Flagging the intention of the key feels right here ("oh this is a ChaCha key!") more than the operation mode did. But again, please let me know if you disagree!

# Why `0xa`?

AES starts with "A", and is an AEAD cipher 😛 I'm not attached to the number range — let me know where to move it and it shall be done!