### PR TITLE
add multiaddr for p2p-circuit-inner

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -101,6 +101,7 @@ p2p-webrtc-star,                multiaddr,      0x0113,         draft,
 p2p-webrtc-direct,              multiaddr,      0x0114,         draft,
 p2p-stardust,                   multiaddr,      0x0115,         draft,
 p2p-circuit,                    multiaddr,      0x0122,         permanent,
+p2p-circuit-inner,              multiaddr,      0x0123,         draft,
 dag-json,                       ipld,           0x0129,         permanent, MerkleDAG json
 udt,                            multiaddr,      0x012d,         draft,
 utp,                            multiaddr,      0x012e,         draft,


### PR DESCRIPTION
As defined in https://github.com/libp2p/specs/pull/353.