### PR TITLE
Add missing variations of sha2

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -19,6 +19,7 @@ keccak-256,                     multihash,      0x1b,           draft,
 keccak-384,                     multihash,      0x1c,           draft,
 keccak-512,                     multihash,      0x1d,           draft,
 blake3,                         multihash,      0x1e,           draft,     BLAKE3 has a default 32 byte output length. The maximum length is (2^64)-1 bytes.
+sha2-384,                       multihash,      0x20,           permanent, aka SHA-384; as specified by FIPS 180-4.
 dccp,                           multiaddr,      0x21,           draft,
 murmur3-128,                    multihash,      0x22,           draft,
 murmur3-32,                     multihash,      0x23,           draft,
@@ -128,6 +129,9 @@ libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2
 car-index-sorted,               serialization,  0x0400,         draft,     CARv2 IndexSorted index format
 car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
+sha2-224,                       multihash,      0x1013,         permanent, aka SHA-224; as specified by FIPS 180-4.
+sha2-512-224,                   multihash,      0x1014,         permanent, aka SHA-512/224; as specified by FIPS 180-4.
+sha2-512-256,                   multihash,      0x1015,         permanent, aka SHA-512/256; as specified by FIPS 180-4.
 ripemd-128,                     multihash,      0x1052,         draft,
 ripemd-160,                     multihash,      0x1053,         draft,
 ripemd-256,                     multihash,      0x1054,         draft,


### PR DESCRIPTION
Per discussion in https://github.com/multiformats/multicodec/issues/205 ,
and further discussion of the numbers,
in https://github.com/multiformats/multicodec/pull/206 .

Most of the variants are shifted into larger number ranges.