### PR TITLE
Add secp256r1 / nistp256 / prime256v1

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -88,6 +88,7 @@ swarm-ns,                       namespace,      0xe4,           draft,     Swarm
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
 secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key (compressed)
+secp256r1-pub,                  key,            0xe8,           draft,     Secp256r1 public key (compressed)
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key


### PR DESCRIPTION
This PR adds a codec to represent a secp256r1 public key, also known as a nistp256 key (see [Appendix A of RFC4492](https://tools.ietf.org/search/rfc4492#appendix-A).

