### PR TITLE
Reserve multihash type for ssz-sha2-256

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -476,6 +476,7 @@ skein1024-1016,                 multihash,      0xb3df,         draft,
 skein1024-1024,                 multihash,      0xb3e0,         draft,
 poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         permanent, Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
 poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         draft,     Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
+ssz-sha2-256,                   multihash,      0xb501,         draft,     SSZ Merkle tree root using SHA2-256 as the hashing function
 iscc,                           softhash,       0xcc01,         draft,     ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,     0xcert Asset Imprint (root hash)
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent, Filecoin piece or sector data commitment merkle node/root (CommP & CommD)

--- a/table.csv
+++ b/table.csv
@@ -476,7 +476,8 @@ skein1024-1016,                 multihash,      0xb3df,         draft,
 skein1024-1024,                 multihash,      0xb3e0,         draft,
 poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         permanent, Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
 poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         draft,     Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
-ssz-sha2-256,                   multihash,      0xb501,         draft,     SSZ Merkle tree root using SHA2-256 as the hashing function
+ssz,                            serialization,  0xb501,         draft,     SimpleSerialize (SSZ) serialization
+ssz-sha2-256-bmt,               multihash,      0xb502,         draft,     SSZ Merkle tree root using SHA2-256 as the hashing function and SSZ serialization for the block binary
 iscc,                           softhash,       0xcc01,         draft,     ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,     0xcert Asset Imprint (root hash)
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent, Filecoin piece or sector data commitment merkle node/root (CommP & CommD)


### PR DESCRIPTION
This introduces an entry to the registry for a multihash that represents a SSZ Merkle root using a SHA2-256 hash function. SSZ is a serialization and Merkleization process that is used extensively in the Ethereum Beacon chain.

The SSZ specification is described in detail here: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#simpleserialize-ssz.