### PR TITLE
add dnslink namespace

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -34,7 +34,6 @@ dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
-dnslink,                        namespace,      0x39,           permanent,
 protobuf,                       serialization,  0x50,           draft,     Protocol Buffers
 cbor,                           ipld,           0x51,           permanent, CBOR
 raw,                            ipld,           0x55,           permanent, raw binary
@@ -88,6 +87,7 @@ swarm-ns,                       namespace,      0xe4,           draft,     Swarm
 ipns-ns,                        namespace,      0xe5,           draft,     IPNS path
 zeronet,                        namespace,      0xe6,           draft,     ZeroNet site address
 secp256k1-pub,                  key,            0xe7,           draft,     Secp256k1 public key (compressed)
+dnslink,                        namespace,      0xe8,           permanent, DNSLink path
 bls12_381-g1-pub,               key,            0xea,           draft,     BLS12-381 public key in the G1 field
 bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12-381 public key in the G2 field
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key

--- a/table.csv
+++ b/table.csv
@@ -34,6 +34,7 @@ dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
+dnslink,                        namespace,      0x39,           permanent,
 protobuf,                       serialization,  0x50,           draft,     Protocol Buffers
 cbor,                           ipld,           0x51,           permanent, CBOR
 raw,                            ipld,           0x55,           permanent, raw binary


### PR DESCRIPTION
Rationale:
- been around since  the very early days, seems we just never added it because `/ipns/` was good enough for existing use cases 
  - we already have dnsaddr, which works similar way, but for multiaddrs  (TXT records), adding dnslink removes the uncertainty if someone wants to use codec to distinguish between the two
  - cc @Stebalien in case I am missing any reason we should not have this as a codec
- we want to support DNSLink chaining without `/ipns/` in TXT records, so it is useful for non-IPFS use cases
  -  `dnslink=/dnslink/example.com` 
  - (we had to remove mentions of it https://github.com/ipfs/ipfs-companion/issues/1039 for now due to ambiguity and lack of support in our stack, this PR will enable us to close this gap)
- we want a clear way for pinning DNSLink names within Pinning Service API (https://github.com/ipfs/pinning-services-api-spec/issues/85), that is separate from pinning IPFS (cryptographic records)


