### PR TITLE
remove bmt entry

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -79,7 +79,6 @@ stellar-block,                  ipld,           0xd0,           draft,     Stell
 stellar-tx,                     ipld,           0xd1,           draft,     Stellar Tx
 md4,                            multihash,      0xd4,           draft,
 md5,                            multihash,      0xd5,           draft,
-bmt,                            multihash,      0xd6,           draft,     Binary Merkle Tree Hash
 decred-block,                   ipld,           0xe0,           draft,     Decred Block
 decred-tx,                      ipld,           0xe1,           draft,     Decred Tx
 ipld-ns,                        namespace,      0xe2,           draft,     IPLD path


### PR DESCRIPTION
This is an ongoing pain-point because it serves as an example of the very weird edges of the multicodec table. I'm not aware of any real use; or even how it could be practically used. It's not a "hash function", but describes a hash process that needs additional "function" information. I suspect it has its genesis in looking at Bitcoin et. al., but for those binary merkle trees we use `bitcoin-tx` coupled with `dbl-sha2-256` which gives us all the information we need.

`ssz-sha2-256-bmt` is a newer example of an entry that's more descriptive, it stretches definitions a bit here but describes a hashing process within a format. It's probably not an awesome example either, but it's closer to a standard (current) understanding of multiformats than `bmt` is (not just because it can actually be implemented and used).

Can anyone think of a good reason to keep this entry, or can we remove it as cruft?