### PR TITLE
Add 'host-header' to table.csv

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -126,6 +126,7 @@ ws,                             multiaddr,      0x01dd,         permanent,
 wss,                            multiaddr,      0x01de,         permanent,
 p2p-websocket-star,             multiaddr,      0x01df,         permanent,
 http,                           multiaddr,      0x01e0,         draft,
+host-header,                    multiaddr,      0x01e1,         draft,     HTTP Host RFC 2616 § 14.23
 swhid-1-snp,                    ipld,           0x01f0,         draft,     SoftWare Heritage persistent IDentifier version 1 snapshot
 json,                           ipld,           0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack


### PR DESCRIPTION
Host header as defined by HTTP [RFC 2616 § 14.23](https://www.rfc-editor.org/rfc/rfc2616#section-14.23).

Relates to multiformats/multiaddr#144 and libp2p/go-libp2p#1829

cc @MarcoPolo 