### PR TITLE
add a new QUIC codepoint for QUIC v1

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -119,7 +119,7 @@ garlic32,                       multiaddr,      0x01bf,         draft,     I2P b
 tls,                            multiaddr,      0x01c0,         draft,
 sni,                            multiaddr,      0x01c1,         draft,     Server Name Indication RFC 6066 § 3
 noise,                          multiaddr,      0x01c6,         draft,
-quic-draft29,                   multiaddr,      0x01cc,         permanent,
+quic,                           multiaddr,      0x01cc,         permanent,
 quic-v1,                        multiaddr,      0x01cd,         permanent,
 webtransport,                   multiaddr,      0x01d1,         draft,
 certhash,                       multiaddr,      0x01d2,         draft,     TLS certificate's fingerprint as a multihash

--- a/table.csv
+++ b/table.csv
@@ -119,7 +119,8 @@ garlic32,                       multiaddr,      0x01bf,         draft,     I2P b
 tls,                            multiaddr,      0x01c0,         draft,
 sni,                            multiaddr,      0x01c1,         draft,     Server Name Indication RFC 6066 § 3
 noise,                          multiaddr,      0x01c6,         draft,
-quic,                           multiaddr,      0x01cc,         permanent,
+quic-draft29,                   multiaddr,      0x01cc,         permanent,
+quic-v1,                        multiaddr,      0x01cd,         permanent,
 webtransport,                   multiaddr,      0x01d1,         draft,
 certhash,                       multiaddr,      0x01d2,         draft,     TLS certificate's fingerprint as a multihash
 ws,                             multiaddr,      0x01dd,         permanent,


### PR DESCRIPTION
See https://github.com/multiformats/multiaddr/issues/145 for a detailed explanation.

Implementations MAY choose to continue accepting `/quic` multiaddresses (and interpret them as `quic-draft29` or `quic-v1` at their discretion).

---

cc @elenaf9 @thomaseizinger, who are apparently not part of the multiformats org yet.