### PR TITLE
Add multidid code

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -5,7 +5,7 @@ cidv2,                          cid,            0x02,           draft,     CIDv2
 cidv3,                          cid,            0x03,           draft,     CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
-multidid                        multiformat,    0x0d,           draft,     Compact encoding for Decentralized Identifers
+multidid,                       multiformat,    0x0d,           draft,     Compact encoding for Decentralized Identifers
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,

--- a/table.csv
+++ b/table.csv
@@ -138,6 +138,7 @@ car-index-sorted,               serialization,  0x0400,         draft,     CARv2
 car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
 transport-bitswap,              transport,      0x0900,         draft,     Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,     Filecoin graphsync datatransfer
+multidid,                       multiformat,    0x0d1d,         draft,     Compact encoding for Decentralized Identifers
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent, aka SHA-224; as specified by FIPS 180-4.
 sha2-512-224,                   multihash,      0x1014,         permanent, aka SHA-512/224; as specified by FIPS 180-4.
@@ -496,7 +497,6 @@ bls-12381-g1-sig,               varsig,         0xd0ea,         draft,     G1 si
 bls-12381-g2-sig,               varsig,         0xd0eb,         draft,     G2 signature for BLS-12381-G1
 eddsa,                          varsig,         0xd0ed,         draft,     Edwards-Curve Digital Signature Algorithm
 eip-191,                        varsig,         0xd191,         draft,     EIP-191 Ethereum Signed Data Standard
-multidid,                       multiformat,    0x0d1d,         draft,     Compact encoding for Decentralized Identifers
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent, Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         permanent, Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)
 plaintextv2,                    multiaddr,      0x706c61,       draft,

--- a/table.csv
+++ b/table.csv
@@ -5,7 +5,6 @@ cidv2,                          cid,            0x02,           draft,     CIDv2
 cidv3,                          cid,            0x03,           draft,     CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
-multidid,                       multiformat,    0x0d,           draft,     Compact encoding for Decentralized Identifers
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,
@@ -497,6 +496,7 @@ bls-12381-g1-sig,               varsig,         0xd0ea,         draft,     G1 si
 bls-12381-g2-sig,               varsig,         0xd0eb,         draft,     G2 signature for BLS-12381-G1
 eddsa,                          varsig,         0xd0ed,         draft,     Edwards-Curve Digital Signature Algorithm
 eip-191,                        varsig,         0xd191,         draft,     EIP-191 Ethereum Signed Data Standard
+multidid,                       multiformat,    0x0d1d,         draft,     Compact encoding for Decentralized Identifers
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent, Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         permanent, Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)
 plaintextv2,                    multiaddr,      0x706c61,       draft,

--- a/table.csv
+++ b/table.csv
@@ -5,6 +5,7 @@ cidv2,                          cid,            0x02,           draft,     CIDv2
 cidv3,                          cid,            0x03,           draft,     CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
+multidid                        multiformat,    0x0d,           draft,     Compact encoding for Decentralized Identifers
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,


### PR DESCRIPTION
This PR adds the `0x0d` code for representing a [multidid](https://github.com/ChainAgnostic/multidid/pull/2). 

Picked a quite low number, which seems reasonable given the possible future prevalence of DIDs.