### PR TITLE
Add BARE Message Encoding

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -133,6 +133,7 @@ swhid-1-snp,                    ipld,           0x01f0,         draft,     SoftW
 json,                           ipld,           0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
 car,                            serialization,  0x0202,         draft,     Content Addressable aRchive (CAR)
+bare,                           ipld,           0x0203,         draft,     Binary Application Record Encoding (BARE)
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type
 libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2p relay reservation voucher
 memorytransport,                libp2p,         0x0309,         permanent, in memory transport for self-dialing and testing; arbitrary


### PR DESCRIPTION
BARE stands for Binary Application Record Encoding.

See https://baremessages.org for more details.
Registered as a draft RFC: https://datatracker.ietf.org/doc/draft-devault-bare/
