### PR TITLE
Add IPNS Record code

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -133,6 +133,7 @@ swhid-1-snp,                    ipld,           0x01f0,         draft,     SoftW
 json,                           ipld,           0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
 car,                            serialization,  0x0202,         draft,     Content Addressable aRchive (CAR)
+ipns-record,                    serialization,  0x0300,         permanent, Signed IPNS Record
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type
 libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2p relay reservation voucher
 memorytransport,                libp2p,         0x0309,         permanent, in memory transport for self-dialing and testing; arbitrary


### PR DESCRIPTION
This PR proposes adding `ipns-record`, like we already have one for `libp2p-peer-record`.

Rationale / potential uses:

-  Main one: we should add a dedicated codec for IPNS Record, otherwise people will use `ipns`(0xe5) code which would be invalid, as it indicates IPNS "namespace".
- [IPIP-351](https://github.com/ipfs/specs/pull/351)  will ship in Kubo 0.19 and will allow fetching signed (verifiable) IPNS Record.
  - In the future `/ipns/{id}?format=car` could return a CAR with `ipns-record` as an additional block.
- IPNI wants to support IPNS Records, but need codec (https://github.com/ipni/specs/pull/4)
