### PR TITLE
Add sr25519

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -94,6 +94,7 @@ bls12_381-g2-pub,               key,            0xeb,           draft,     BLS12
 x25519-pub,                     key,            0xec,           draft,     Curve25519 public key
 ed25519-pub,                    key,            0xed,           draft,     Ed25519 public key
 bls12_381-g1g2-pub,             key,            0xee,           draft,     BLS12-381 concatenated public keys in both the G1 and G2 fields
+sr25519-pub,                    key,            0xef,           draft,     Sr25519 public key
 dash-block,                     ipld,           0xf0,           draft,     Dash Block
 dash-tx,                        ipld,           0xf1,           draft,     Dash Tx
 swarm-manifest,                 ipld,           0xfa,           draft,     Swarm Manifest
@@ -162,6 +163,7 @@ sm2-pub,                        key,            0x1206,         draft,     SM2 p
 ed25519-priv,                   key,            0x1300,         draft,     Ed25519 private key
 secp256k1-priv,                 key,            0x1301,         draft,     Secp256k1 private key
 x25519-priv,                    key,            0x1302,         draft,     Curve25519 private key
+sr25519-priv,                   key,            0x1303,         draft,     Sr25519 private key
 rsa-priv,                       key,            0x1305,         draft,     RSA private key
 kangarootwelve,                 multihash,      0x1d01,         draft,     KangarooTwelve is an extendable-output hash function based on Keccak-p
 silverpine,                     multiaddr,      0x3f42,         draft,     Experimental QUIC over yggdrasil and ironwood routing protocol


### PR DESCRIPTION
Schnorrkel/Ristretto x25519 ("sr25519") is a schnorr signature scheme on [Ristretto](https://ristretto.group/) compressed ed25519 points used in [Substrate](https://github.com/paritytech/substrate) framework.

You can find more information:

- Schnorrkel: https://github.com/w3f/schnorrkel
- Ristretto: https://ristretto.group/ristretto.html