### PR TITLE
feat: add webrtc-w3c

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -105,7 +105,7 @@ p2p-webrtc-star,                multiaddr,      0x0113,         draft,
 p2p-webrtc-direct,              multiaddr,      0x0114,         draft,
 p2p-stardust,                   multiaddr,      0x0115,         draft,
 webrtc,                         multiaddr,      0x0118,         draft,     WebRTC
-webrtc-w3c, 			muliaddr, 	0x0119, 	draft,     WebRTC connection establishment using flow described in W3C specification	
+webrtc-w3c,                     muliaddr,       0x0119,         draft,     WebRTC connection establishment using flow described in W3C specification	
 p2p-circuit,                    multiaddr,      0x0122,         permanent,
 dag-json,                       ipld,           0x0129,         permanent, MerkleDAG json
 udt,                            multiaddr,      0x012d,         draft,

--- a/table.csv
+++ b/table.csv
@@ -105,6 +105,7 @@ p2p-webrtc-star,                multiaddr,      0x0113,         draft,
 p2p-webrtc-direct,              multiaddr,      0x0114,         draft,
 p2p-stardust,                   multiaddr,      0x0115,         draft,
 webrtc,                         multiaddr,      0x0118,         draft,     WebRTC
+webrtc-w3c, 			muliaddr, 	0x0119, 	draft,     WebRTC connection establishment using flow described in W3C specification	
 p2p-circuit,                    multiaddr,      0x0122,         permanent,
 dag-json,                       ipld,           0x0129,         permanent, MerkleDAG json
 udt,                            multiaddr,      0x012d,         draft,


### PR DESCRIPTION
Adds the webrtc-w3c multiaddr protocol based on the following spec: https://github.com/libp2p/specs/pull/497