### PR TITLE
fix: Rename webrtc-w3c to webrtc-private-to-private

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -105,7 +105,7 @@ p2p-webrtc-star,                multiaddr,      0x0113,         draft,
 p2p-webrtc-direct,              multiaddr,      0x0114,         draft,
 p2p-stardust,                   multiaddr,      0x0115,         draft,
 webrtc,                         multiaddr,      0x0118,         draft,     WebRTC
-webrtc-w3c,                     multiaddr,      0x0119,         draft,     WebRTC connection establishment using flow described in W3C specification	
+webrtc-private-to-private,      multiaddr,      0x0119,         draft,     WebRTC transport establishing connection between two private nodes
 p2p-circuit,                    multiaddr,      0x0122,         permanent,
 dag-json,                       ipld,           0x0129,         permanent, MerkleDAG json
 udt,                            multiaddr,      0x012d,         draft,


### PR DESCRIPTION
We have decided to rename `webrtc-w3c` to `webrtc-private-to-private`. See rational in https://github.com/multiformats/multiaddr/pull/150/#issuecomment-1460912728.

No software has been released using `webrtc-w3c`, thus renaming is not a breaking change.

Follow up to #316.