### PR TITLE
Add a transport code to indicate content is provided via car

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -143,7 +143,7 @@ car-index-sorted,               serialization,  0x0400,         draft,     CARv2
 car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
 transport-bitswap,              transport,      0x0900,         draft,     Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,     Filecoin graphsync datatransfer
-transport-gateway-trustless,    transport,      0x0920,         draft,     HTTP car datatransfer
+transport-ipfs-gateway-http,    transport,      0x0920,         draft,     HTTP car datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,     Compact encoding for Decentralized Identifers
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent, aka SHA-224; as specified by FIPS 180-4.

--- a/table.csv
+++ b/table.csv
@@ -143,7 +143,7 @@ car-index-sorted,               serialization,  0x0400,         draft,      CARv
 car-multihash-index-sorted,     serialization,  0x0401,         draft,      CARv2 MultihashIndexSorted index format
 transport-bitswap,              transport,      0x0900,         draft,      Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
-transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP car datatransfer
+transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent,  aka SHA-224; as specified by FIPS 180-4.

--- a/table.csv
+++ b/table.csv
@@ -143,6 +143,7 @@ car-index-sorted,               serialization,  0x0400,         draft,     CARv2
 car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
 transport-bitswap,              transport,      0x0900,         draft,     Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,     Filecoin graphsync datatransfer
+transport-gateway-trustless,    transport,      0x0920,         draft,     HTTP car datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,     Compact encoding for Decentralized Identifers
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent, aka SHA-224; as specified by FIPS 180-4.


### PR DESCRIPTION
per the trustless gateway spec

The exact semantics of this spec are evolving, but might as well reserve a code that we can use for indicating the existence of an HTTP endpoint for index providers.