### PR TITLE
Add Varsig Multiformat

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -506,7 +506,7 @@ ssz-sha2-256-bmt,               multihash,      0xb502,         draft,      SSZ 
 json-jcs,                       ipld,           0xb601,         draft,      The result of canonicalizing an input according to JCS - JSON Canonicalisation Scheme (RFC 8785)
 iscc,                           softhash,       0xcc01,         draft,      ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
-varsig,                         varsig,         0xd000,         draft,      Namespace for all not yet standard signature algorithms
+nonstandard-sig,                varsig,         0xd000,         draft,      Namespace for all not yet standard signature algorithms
 es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
 bls-12381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
 bls-12381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1

--- a/table.csv
+++ b/table.csv
@@ -506,7 +506,7 @@ ssz-sha2-256-bmt,               multihash,      0xb502,         draft,      SSZ 
 json-jcs,                       ipld,           0xb601,         draft,      The result of canonicalizing an input according to JCS - JSON Canonicalisation Scheme (RFC 8785)
 iscc,                           softhash,       0xcc01,         draft,      ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
-nonstandard-sig,                varsig,         0xd000,         draft,      Namespace for all not yet standard signature algorithms
+nonstandard-sig,                varsig,         0xd000,    deprecated,      Namespace for all not yet standard signature algorithms
 es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
 bls-12381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
 bls-12381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1

--- a/table.csv
+++ b/table.csv
@@ -31,6 +31,7 @@ multicodec,                     multiformat,    0x30,           draft,
 multihash,                      multiformat,    0x31,           draft,
 multiaddr,                      multiformat,    0x32,           draft,
 multibase,                      multiformat,    0x33,           draft,
+varsig,                         multiformat,    0x34,           draft,      Variable signature (varsig) multiformat
 dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,

--- a/table.csv
+++ b/table.csv
@@ -507,7 +507,7 @@ ssz-sha2-256-bmt,               multihash,      0xb502,         draft,      SSZ 
 json-jcs,                       ipld,           0xb601,         draft,      The result of canonicalizing an input according to JCS - JSON Canonicalisation Scheme (RFC 8785)
 iscc,                           softhash,       0xcc01,         draft,      ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
-nonstandard-sig,                varsig,         0xd000,    deprecated,      Namespace for all not yet standard signature algorithms
+nonstandard-sig,                varsig,         0xd000,         deprecated, Namespace for all not yet standard signature algorithms
 es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
 bls-12381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
 bls-12381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1


### PR DESCRIPTION
Hey all 👋 We ended up wanting a LOT more flexibilty in Varsig than a codec tag, and broke it out into its own spec here: https://github.com/ChainAgnostic/varsig

This is essentially `multisig`, except that sequence of letters has a widely-used namespace conflict in multisig wallets. To avoid confusion, it's "varsig", but almost certainly belongs in the block with the other multiformats.

If useful, we can remove the previously-added `draft` signature types from this table, but I know  historically there's been resistence to that. I'm happy either way 👍 