### PR TITLE
Add code for SCION multiaddrs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -531,3 +531,4 @@ es256,                          varsig,         0xd01200,       draft,      ES25
 es284,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm
 rs256,                          varsig,         0xd01205,       draft,      RS256 Signature Algorithm
+scion,                          multiaddr,      0xd02000,       draft,      SCION Internet architecture


### PR DESCRIPTION
We'd like to upstream libp2p support for the [SCION](https://scion-architecture.net) Internet architecture. As a first step, this PR reserves a code for SCION multiaddrs like `/scion/19-ffaa:1:1079...`.