### PR TITLE
add fr32-sha2-256-trunc254-padded-binary-tree multihash

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -146,7 +146,7 @@ transport-bitswap,              transport,      0x0900,         draft,      Bits
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
 transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
-fr32-sha2-256-trunc254-padded-binary-tree, multihash, 0x1011, draft, A balanced binary tree hash used in Filecoin Piece Commitments
+fr32-sha256-trunc254-padbintree,multihash,      0x1011,         draft,      A balanced binary tree hash used in Filecoin Piece Commitments
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent,  aka SHA-224; as specified by FIPS 180-4.
 sha2-512-224,                   multihash,      0x1014,         permanent,  aka SHA-512/224; as specified by FIPS 180-4.

--- a/table.csv
+++ b/table.csv
@@ -146,6 +146,7 @@ transport-bitswap,              transport,      0x0900,         draft,      Bits
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
 transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
+fr32-sha2-256-trunc254-padded-binary-tree, multihash, 0x1011, draft, A balanced binary tree hash used in Filecoin Piece Commitments
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent,  aka SHA-224; as specified by FIPS 180-4.
 sha2-512-224,                   multihash,      0x1014,         permanent,  aka SHA-512/224; as specified by FIPS 180-4.

--- a/table.csv
+++ b/table.csv
@@ -150,7 +150,7 @@ transport-bitswap,              transport,      0x0900,         draft,      Bits
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
 transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
-fr32-sha256-trunc254-padbintree,multihash,      0x1011,         draft,      A balanced binary tree hash used in Filecoin Piece Commitments
+fr32-sha256-trunc254-padbintree,multihash,      0x1011,         draft,      A balanced binary tree hash used in Filecoin Piece Commitments as described in FRC-0069
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent,  aka SHA-224; as specified by FIPS 180-4.
 sha2-512-224,                   multihash,      0x1014,         permanent,  aka SHA-512/224; as specified by FIPS 180-4.


### PR DESCRIPTION
This PR reserves a single multihash code. The request here comes from the Filecoin ecosystem which is already using the underlying hashes here in relation to the codes reserved in https://github.com/multiformats/multicodec/pull/170 and https://github.com/multiformats/multicodec/pull/172.

However, it turns out the approach taken in the reservation of those codes was insufficient and as a result there’s a new [spec proposal](https://github.com/filecoin-project/FIPs/pull/758) for a different multihash to better represent the data being referred to.

At a high level there were three approaches for describing these trees given [here](https://github.com/multiformats/multicodec/pull/161#issuecomment-614429691). We went with option 2, but that turns out to have been a mistake so now we’re going with option 3.

---

### Why is this a good idea when you already had a code here?

You live and you learn. It turns out that for the particular data being dealt with the approach taken originally was problematic (and is IIUC largely [why](https://github.com/multiformats/multicodec/pull/172#issuecomment-620392474) the related codec entries were tagged as `filecoin` rather than IPLD) and this one makes life easier. The reason CID and multihash exist is to make it easier to evolve through mistakes, this is one example of that.

### Should other applications of merkle-tree hashes lean on custom multihashes rather than reusing existing ones?

As with my [comment](https://github.com/multiformats/multicodec/issues/204#issuecomment-1104404093) around IPLD codecs from a while ago I think the answer lies in what the application gain/loses out on by not reusing existing multihashes.

### Is it reasonable to have multiple codes dealing with effectively the same data?

Situationally, yes. In this case it turns out there are better and worse ways to describe the same data and people might even disagree on what those are. The table allows us to support these options.

A related example I’ve heard mentioned in the past was if someone wanted to register codes for the internal components of the blake3 tree so that data could be referred to as either a Blake3 multihash of a 1GiB file, or a more specific Blake3 internal-node multihash for the root of the tree whose leaves are the 1GiB file. On the surface this seems like a reasonable request as well.

cc @ribasushi @willscott @rvagg @vmx

(p.s. I hope Rod and Volker forgive me for making them relive #161, #170 and #172)