### PR TITLE
add Cryptid codecs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -5,6 +5,9 @@ cidv2,                          cid,            0x02,           draft,      CIDv
 cidv3,                          cid,            0x03,           draft,      CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
+vlad,                           cid,            0x07,           draft,      Verifiable Long-lived ADdress
+provenance-log,                 ipld,           0x08,           draft,      Verifiable and permissioned append only log
+provenance-log-entry,           ipld,           0x09,           draft,      Verifiable and permissioned append only log
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,
@@ -36,6 +39,9 @@ dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
+multisig,                       multiformat,    0x39,           draft,      Digital signature multiformat
+multikey,                       multiformat,    0x3a,           draft,      Encryption key multiformat 
+nonce,                          key,            0x3b,           draft,      Nonce random value
 protobuf,                       serialization,  0x50,           draft,      Protocol Buffers
 cbor,                           ipld,           0x51,           permanent,  CBOR
 raw,                            ipld,           0x55,           permanent,  raw binary
@@ -71,6 +77,7 @@ aes-192,                        key,            0xa1,           draft,      192-
 aes-256,                        key,            0xa2,           draft,      256-bit AES symmetric key
 chacha-128,                     key,            0xa3,           draft,      128-bit ChaCha symmetric key
 chacha-256,                     key,            0xa4,           draft,      256-bit ChaCha symmetric key
+chacha20-poly1305,              multikey,       0xa5,           draft,      ChaCha20_Poly1305 encryption scheme
 bitcoin-block,                  ipld,           0xb0,           permanent,  Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           permanent,  Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           permanent,  Bitcoin Witness Commitment
@@ -176,6 +183,25 @@ p521-priv,                      key,            0x1308,         draft,      P-52
 bls12_381-g1-priv,              key,            0x1309,         draft,      BLS12-381 G1 private key
 bls12_381-g2-priv,              key,            0x130a,         draft,      BLS12-381 G2 private key
 bls12_381-g1g2-priv,            key,            0x130b,         draft,      BLS12-381 G1 and G2 private key
+bls12_381-g1-pub-share,         key,            0x130c,         draft,      BLS12-381 G1 public key share
+bls12_381-g2-pub-share,         key,            0x130d,         draft,      BLS12-381 G2 public key share
+bls12_381-g1-priv-share,        key,            0x130e,         draft,      BLS12-381 G1 private key share
+bls12_381-g2-priv-share,        key,            0x130f,         draft,      BLS12-381 G2 private key share
+lamport-sha3-512-pub,           key,            0x1a14,         draft,      Lamport public key based on SHA3-512
+lamport-sha3-384-pub,           key,            0x1a15,         draft,      Lamport public key based on SHA3-384
+lamport-sha3-256-pub,           key,            0x1a16,         draft,      Lamport public key based on SHA3-256
+lamport-sha3-512-priv,          key,            0x1a24,         draft,      Lamport private key based on SHA3-512
+lamport-sha3-384-priv,          key,            0x1a25,         draft,      Lamport private key based on SHA3-384
+lamport-sha3-256-priv,          key,            0x1a26,         draft,      Lamport private key based on SHA3-256
+lamport-sha3-512-priv-share,    key,            0x1a34,         draft,      Lamport private key share based on SHA3-512 and split with Shamir gf256
+lamport-sha3-384-priv-share,    key,            0x1a35,         draft,      Lamport private key share based on SHA3-384 and split with Shamir gf256
+lamport-sha3-256-priv-share,    key,            0x1a36,         draft,      Lamport private key share based on SHA3-256 and split with Shamir gf256
+lamport-sha3-512-sig,           multisig,       0x1a44,         draft,      Lamport signature based on SHA3-512
+lamport-sha3-384-sig,           multisig,       0x1a45,         draft,      Lamport signature based on SHA3-384
+lamport-sha3-256-sig,           multisig,       0x1a46,         draft,      Lamport signature based on SHA3-256
+lamport-sha3-512-sig-share,     multisig,       0x1a54,         draft,      Lamport signature share based on SHA3-512 and split with Shamir gf256
+lamport-sha3-384-sig-share,     multisig,       0x1a55,         draft,      Lamport signature share based on SHA3-384 and split with Shamir gf256
+lamport-sha3-256-sig-share,     multisig,       0x1a56,         draft,      Lamport signature share based on SHA3-256 and split with Shamir gf256
 kangarootwelve,                 multihash,      0x1d01,         draft,      KangarooTwelve is an extendable-output hash function based on Keccak-p
 aes-gcm-256,                    encryption,     0x2000,         draft,      AES Galois/Counter Mode with 256-bit key and 12-byte IV
 silverpine,                     multiaddr,      0x3f42,         draft,      Experimental QUIC over yggdrasil and ironwood routing protocol
@@ -515,10 +541,13 @@ json-jcs,                       ipld,           0xb601,         draft,      The 
 iscc,                           softhash,       0xcc01,         draft,      ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
 nonstandard-sig,                varsig,         0xd000,         deprecated, Namespace for all not yet standard signature algorithms
-es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
-bls-12381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
-bls-12381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1
-eddsa,                          varsig,         0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
+bcrypt-pbkdf,                   multihash,      0xd00d,         draft,      Bcrypt-PBKDF key derivation function
+es256k,                         multisig,       0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
+bls12_381-g1-sig,               multisig,       0xd0ea,         draft,      G1 signature for BLS-12381-G2
+bls12_381-g2-sig,               multisig,       0xd0eb,         draft,      G2 signature for BLS-12381-G1
+eddsa,                          multisig,       0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
+bls12_381-g1-sig-share,         multisig,       0xd0fa,         draft,      G1 signature share for BLS-12381-G2
+bls12_381-g2-sig-share,         multisig,       0xd0fb,         draft,      G1 signature share for BLS-12381-G2
 eip-191,                        varsig,         0xd191,         draft,      EIP-191 Ethereum Signed Data Standard
 jwk_jcs-pub,                    key,            0xeb51,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the public key. Serialisation based on JCS (RFC 8785)
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent,  Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
@@ -534,8 +563,8 @@ skynet-ns,                      namespace,      0xb19910,       draft,      Skyn
 arweave-ns,                     namespace,      0xb29910,       draft,      Arweave Namespace
 subspace-ns,                    namespace,      0xb39910,       draft,      Subspace Network Namespace
 kumandra-ns,                    namespace,      0xb49910,       draft,      Kumandra Network Namespace
-es256,                          varsig,         0xd01200,       draft,      ES256 Signature Algorithm
-es284,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
-es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm
-rs256,                          varsig,         0xd01205,       draft,      RS256 Signature Algorithm
+es256,                          multisig,       0xd01200,       draft,      ES256 Signature Algorithm
+es284,                          multisig,       0xd01201,       draft,      ES384 Signature Algorithm
+es512,                          multisig,       0xd01202,       draft,      ES512 Signature Algorithm
+rs256,                          multisig,       0xd01205,       draft,      RS256 Signature Algorithm
 scion,                          multiaddr,      0xd02000,       draft,      SCION Internet architecture

--- a/table.csv
+++ b/table.csv
@@ -41,7 +41,7 @@ dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
 multisig,                       multiformat,    0x39,           draft,      Digital signature multiformat
 multikey,                       multiformat,    0x3a,           draft,      Encryption key multiformat 
-nonce,                          key,            0x3b,           draft,      Nonce random value
+nonce,                          nonce,          0x3b,           draft,      Nonce random value
 protobuf,                       serialization,  0x50,           draft,      Protocol Buffers
 cbor,                           ipld,           0x51,           permanent,  CBOR
 raw,                            ipld,           0x55,           permanent,  raw binary

--- a/table.csv
+++ b/table.csv
@@ -566,16 +566,16 @@ es256,                          varsig,         0xd01200,       draft,      ES25
 es284,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm
 rs256,                          varsig,         0xd01205,       draft,      RS256 Signature Algorithm
-es256k-msig,                    multisig,       0xd01300,       draft,      ES256K Siganture Algorithm (secp256k1) as Multisig
+es256k-msig,                    multisig,       0xd01300,       draft,      ES256K (secp256k1) Signature as Multisig
 bls12_381-g1-msig,              multisig,       0xd01301,       draft,      G1 signature for BLS-12381-G2 as Multisig
 bls12_381-g2-msig,              multisig,       0xd01302,       draft,      G2 signature for BLS-12381-G1 as Multisig
-eddsa-msig,                     multisig,       0xd01303,       draft,      Edwards-Curve Digital Signature Algorithm as Multisig
+eddsa-msig,                     multisig,       0xd01303,       draft,      Edwards-Curve Digital Signature as Multisig
 bls12_381-g1-share-msig,        multisig,       0xd01304,       draft,      G1 threshold signature share for BLS-12381-G2 as Multisig
 bls12_381-g2-share-msig,        multisig,       0xd01305,       draft,      G2 threshold signature share for BLS-12381-G1 as Multisig
 lamport-msig,                   multisig,       0xd01306,       draft,      Lamport signature as Multisig
 lamport-share-msig,             multisig,       0xd01307,       draft,      Lamport threshold signature share as Multisig
-es256-msig,                     multisig,       0xd01308,       draft,      ES256 Signature Algorithm as Multisig
-es384-msig,                     multisig,       0xd01309,       draft,      ES384 Signature Algorithm as Multisig
-es512-msig,                     multisig,       0xd0130a,       draft,      ES512 Signature Algorithm as Multisig
-rs256-msig,                     multisig,       0xd0130b,       draft,      RS256 Signature Algorithm as Multisig
+es256-msig,                     multisig,       0xd01308,       draft,      ECDSA P-256 Signature as Multisig
+es384-msig,                     multisig,       0xd01309,       draft,      ECDSA P-384 Signature as Multisig
+es521-msig,                     multisig,       0xd0130a,       draft,      ECDSA P-521 Signature as Multisig
+rs256-msig,                     multisig,       0xd0130b,       draft,      RS256 Signature as Multisig
 scion,                          multiaddr,      0xd02000,       draft,      SCION Internet architecture

--- a/table.csv
+++ b/table.csv
@@ -575,7 +575,7 @@ bls12_381-g2-share-msig,        multisig,       0xd01305,       draft,      G2 t
 lamport-msig,                   multisig,       0xd01306,       draft,      Lamport signature as Multisig
 lamport-share-msig,             multisig,       0xd01307,       draft,      Lamport threshold signature share as Multisig
 es256-msig,                     multisig,       0xd01308,       draft,      ES256 Signature Algorithm as Multisig
-es284-msig,                     multisig,       0xd01309,       draft,      ES384 Signature Algorithm as Multisig
+es384-msig,                     multisig,       0xd01309,       draft,      ES384 Signature Algorithm as Multisig
 es512-msig,                     multisig,       0xd0130a,       draft,      ES512 Signature Algorithm as Multisig
 rs256-msig,                     multisig,       0xd0130b,       draft,      RS256 Signature Algorithm as Multisig
 scion,                          multiaddr,      0xd02000,       draft,      SCION Internet architecture

--- a/table.csv
+++ b/table.csv
@@ -5,9 +5,9 @@ cidv2,                          cid,            0x02,           draft,      CIDv
 cidv3,                          cid,            0x03,           draft,      CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
-vlad,                           cid,            0x07,           draft,      Verifiable Long-lived ADdress
-provenance-log,                 ipld,           0x08,           draft,      Verifiable and permissioned append only log
-provenance-log-entry,           ipld,           0x09,           draft,      Verifiable and permissioned append only log
+vlad,                           vlad,           0x07,           draft,      Verifiable Long-lived ADdress
+provenance-log,                 serialization,  0x08,           draft,      Verifiable and permissioned append only log
+provenance-log-entry,           serialization,  0x09,           draft,      Verifiable and permissioned append only log
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,
@@ -543,12 +543,10 @@ iscc,                           softhash,       0xcc01,         draft,      ISCC
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
 nonstandard-sig,                varsig,         0xd000,         deprecated, Namespace for all not yet standard signature algorithms
 bcrypt-pbkdf,                   multihash,      0xd00d,         draft,      Bcrypt-PBKDF key derivation function
-es256k,                         multisig,       0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
-bls12_381-g1-sig,               multisig,       0xd0ea,         draft,      G1 signature for BLS-12381-G2
-bls12_381-g2-sig,               multisig,       0xd0eb,         draft,      G2 signature for BLS-12381-G1
-eddsa,                          multisig,       0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
-bls12_381-g1-sig-share,         multisig,       0xd0fa,         draft,      G1 signature share for BLS-12381-G2
-bls12_381-g2-sig-share,         multisig,       0xd0fb,         draft,      G1 signature share for BLS-12381-G2
+es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
+bls12_381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
+bls12_381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1
+eddsa,                          varsig,         0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
 eip-191,                        varsig,         0xd191,         draft,      EIP-191 Ethereum Signed Data Standard
 jwk_jcs-pub,                    key,            0xeb51,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the public key. Serialisation based on JCS (RFC 8785)
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent,  Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
@@ -564,8 +562,20 @@ skynet-ns,                      namespace,      0xb19910,       draft,      Skyn
 arweave-ns,                     namespace,      0xb29910,       draft,      Arweave Namespace
 subspace-ns,                    namespace,      0xb39910,       draft,      Subspace Network Namespace
 kumandra-ns,                    namespace,      0xb49910,       draft,      Kumandra Network Namespace
-es256,                          multisig,       0xd01200,       draft,      ES256 Signature Algorithm
-es284,                          multisig,       0xd01201,       draft,      ES384 Signature Algorithm
-es512,                          multisig,       0xd01202,       draft,      ES512 Signature Algorithm
-rs256,                          multisig,       0xd01205,       draft,      RS256 Signature Algorithm
+es256,                          varsig,         0xd01200,       draft,      ES256 Signature Algorithm
+es284,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
+es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm
+rs256,                          varsig,         0xd01205,       draft,      RS256 Signature Algorithm
+es256k-msig,                    multisig,       0xd01300,       draft,      ES256K Siganture Algorithm (secp256k1) as Multisig
+bls12_381-g1-msig,              multisig,       0xd01301,       draft,      G1 signature for BLS-12381-G2 as Multisig
+bls12_381-g2-msig,              multisig,       0xd01302,       draft,      G2 signature for BLS-12381-G1 as Multisig
+eddsa-msig,                     multisig,       0xd01303,       draft,      Edwards-Curve Digital Signature Algorithm as Multisig
+bls12_381-g1-share-msig,        multisig,       0xd01304,       draft,      G1 threshold signature share for BLS-12381-G2 as Multisig
+bls12_381-g2-share-msig,        multisig,       0xd01305,       draft,      G2 threshold signature share for BLS-12381-G1 as Multisig
+lamport-msig,                   multisig,       0xd01306,       draft,      Lamport signature as Multisig
+lamport-share-msig,             multisig,       0xd01307,       draft,      Lamport threshold signature share as Multisig
+es256-msig,                     multisig,       0xd01308,       draft,      ES256 Signature Algorithm as Multisig
+es284-msig,                     multisig,       0xd01309,       draft,      ES384 Signature Algorithm as Multisig
+es512-msig,                     multisig,       0xd0130a,       draft,      ES512 Signature Algorithm as Multisig
+rs256-msig,                     multisig,       0xd0130b,       draft,      RS256 Signature Algorithm as Multisig
 scion,                          multiaddr,      0xd02000,       draft,      SCION Internet architecture

--- a/table.csv
+++ b/table.csv
@@ -72,7 +72,6 @@ aes-192,                        key,            0xa1,           draft,      192-
 aes-256,                        key,            0xa2,           draft,      256-bit AES symmetric key
 chacha-128,                     key,            0xa3,           draft,      128-bit ChaCha symmetric key
 chacha-256,                     key,            0xa4,           draft,      256-bit ChaCha symmetric key
-chacha20-poly1305,              multikey,       0xa5,           draft,      ChaCha20_Poly1305 encryption scheme
 bitcoin-block,                  ipld,           0xb0,           permanent,  Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           permanent,  Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           permanent,  Bitcoin Witness Commitment
@@ -210,6 +209,7 @@ aes-gcm-256,                    encryption,     0x2000,         draft,      AES 
 silverpine,                     multiaddr,      0x3f42,         draft,      Experimental QUIC over yggdrasil and ironwood routing protocol
 sm3-256,                        multihash,      0x534d,         draft,
 sha256a,                        hash,           0x7012,         draft,      The sum of multiple sha2-256 hashes; as specified by Ceramic CIP-124.
+chacha20-poly1305,              multikey,       0xa000,         draft,      ChaCha20_Poly1305 encryption scheme
 blake2b-8,                      multihash,      0xb201,         draft,      Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,         draft,
 blake2b-24,                     multihash,      0xb203,         draft,

--- a/table.csv
+++ b/table.csv
@@ -169,8 +169,9 @@ x448-pub,                       key,            0x1204,         draft,      X448
 rsa-pub,                        key,            0x1205,         draft,      RSA public key. DER-encoded ASN.1 type RSAPublicKey according to IETF RFC 8017 (PKCS #1)
 sm2-pub,                        key,            0x1206,         draft,      SM2 public key (compressed)
 vlad,                           vlad,           0x1207,         draft,      Verifiable Long-lived ADdress
-provenance-log,                 serialization,  0x1208,         draft,      Verifiable and permissioned append only log
-provenance-log-entry,           serialization,  0x1209,         draft,      Verifiable and permissioned append only log
+provenance-log,                 serialization,  0x1208,         draft,      Verifiable and permissioned append-only log
+provenance-log-entry,           serialization,  0x1209,         draft,      Verifiable and permissioned append-only log entry
+provenance-log-script,          serialization,  0x120a,         draft,      Verifiable and permissioned append-only log script
 multisig,                       multiformat,    0x1239,         draft,      Digital signature multiformat
 multikey,                       multiformat,    0x123a,         draft,      Encryption key multiformat 
 nonce,                          nonce,          0x123b,         draft,      Nonce random value

--- a/table.csv
+++ b/table.csv
@@ -173,7 +173,7 @@ provenance-log,                 serialization,  0x1208,         draft,      Veri
 provenance-log-entry,           serialization,  0x1209,         draft,      Verifiable and permissioned append-only log entry
 provenance-log-script,          serialization,  0x120a,         draft,      Verifiable and permissioned append-only log script
 multisig,                       multiformat,    0x1239,         draft,      Digital signature multiformat
-multikey,                       multiformat,    0x123a,         draft,      Encryption key multiformat 
+multikey,                       multiformat,    0x123a,         draft,      Encryption key multiformat
 nonce,                          nonce,          0x123b,         draft,      Nonce random value
 ed25519-priv,                   key,            0x1300,         draft,      Ed25519 private key
 secp256k1-priv,                 key,            0x1301,         draft,      Secp256k1 private key
@@ -546,8 +546,8 @@ zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xce
 nonstandard-sig,                varsig,         0xd000,         deprecated, Namespace for all not yet standard signature algorithms
 bcrypt-pbkdf,                   multihash,      0xd00d,         draft,      Bcrypt-PBKDF key derivation function
 es256k,                         varsig,         0xd0e7,         draft,      ES256K Siganture Algorithm (secp256k1)
-bls12_381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
-bls12_381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1
+bls-12381-g1-sig,               varsig,         0xd0ea,         draft,      G1 signature for BLS-12381-G2
+bls-12381-g2-sig,               varsig,         0xd0eb,         draft,      G2 signature for BLS-12381-G1
 eddsa,                          varsig,         0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
 eip-191,                        varsig,         0xd191,         draft,      EIP-191 Ethereum Signed Data Standard
 jwk_jcs-pub,                    key,            0xeb51,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the public key. Serialisation based on JCS (RFC 8785)

--- a/table.csv
+++ b/table.csv
@@ -5,9 +5,6 @@ cidv2,                          cid,            0x02,           draft,      CIDv
 cidv3,                          cid,            0x03,           draft,      CIDv3
 ip4,                            multiaddr,      0x04,           permanent,
 tcp,                            multiaddr,      0x06,           permanent,
-vlad,                           vlad,           0x07,           draft,      Verifiable Long-lived ADdress
-provenance-log,                 serialization,  0x08,           draft,      Verifiable and permissioned append only log
-provenance-log-entry,           serialization,  0x09,           draft,      Verifiable and permissioned append only log
 sha1,                           multihash,      0x11,           permanent,
 sha2-256,                       multihash,      0x12,           permanent,
 sha2-512,                       multihash,      0x13,           permanent,
@@ -39,9 +36,6 @@ dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
-multisig,                       multiformat,    0x39,           draft,      Digital signature multiformat
-multikey,                       multiformat,    0x3a,           draft,      Encryption key multiformat 
-nonce,                          nonce,          0x3b,           draft,      Nonce random value
 protobuf,                       serialization,  0x50,           draft,      Protocol Buffers
 cbor,                           ipld,           0x51,           permanent,  CBOR
 raw,                            ipld,           0x55,           permanent,  raw binary
@@ -174,6 +168,12 @@ ed448-pub,                      key,            0x1203,         draft,      Ed44
 x448-pub,                       key,            0x1204,         draft,      X448 public Key
 rsa-pub,                        key,            0x1205,         draft,      RSA public key. DER-encoded ASN.1 type RSAPublicKey according to IETF RFC 8017 (PKCS #1)
 sm2-pub,                        key,            0x1206,         draft,      SM2 public key (compressed)
+vlad,                           vlad,           0x1207,         draft,      Verifiable Long-lived ADdress
+provenance-log,                 serialization,  0x1208,         draft,      Verifiable and permissioned append only log
+provenance-log-entry,           serialization,  0x1209,         draft,      Verifiable and permissioned append only log
+multisig,                       multiformat,    0x1239,         draft,      Digital signature multiformat
+multikey,                       multiformat,    0x123a,         draft,      Encryption key multiformat 
+nonce,                          nonce,          0x123b,         draft,      Nonce random value
 ed25519-priv,                   key,            0x1300,         draft,      Ed25519 private key
 secp256k1-priv,                 key,            0x1301,         draft,      Secp256k1 private key
 x25519-priv,                    key,            0x1302,         draft,      Curve25519 private key


### PR DESCRIPTION
This adds a number of multicodec values for various Cryptid projects ahead of the public release of the code. Most of the code is already available:
* [Multicid](https://github.com/cryptidtech/multicid)
  * Contains the VLAD implementation. [Spec](https://github.com/cryptidtech/provenance-specifications/blob/main/specifications/vlad.md)
* [Multisig](https://github.com/cryptidtech/multisig)
  * [Spec](https://github.com/cryptidtech/provenance-specifications/blob/main/specifications/multisig.md) 
* [Multikey](https://github.com/cryptidtech/multikey)
  * [Spec](https://github.com/cryptidtech/provenance-specifications/blob/main/specifications/multikey.md)
  *Contains the Nonce implementation as well. [Spec](https://github.com/cryptidtech/provenance-specifications/blob/main/specifications/nonce.md) 