### PR TITLE
Codecs for ENS Contenthash: URI [0xF2] and Data URL [0xF3]

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -100,6 +100,8 @@ bls12_381-g1g2-pub,             key,            0xee,           draft,      BLS1
 sr25519-pub,                    key,            0xef,           draft,      Sr25519 public key
 dash-block,                     ipld,           0xf0,           draft,      Dash Block
 dash-tx,                        ipld,           0xf1,           draft,      Dash Tx
+uri,                            namespace,      0xf2,           draft,      URI: <url: utf8-string>
+data-url,                       data,           0xf3,           draft,      data URL: <len(mime): uint8><mime: ascii-string><data: uint8[]>
 swarm-manifest,                 ipld,           0xfa,           draft,      Swarm Manifest
 swarm-feed,                     ipld,           0xfb,           draft,      Swarm Feed
 beeson,                         ipld,           0xfc,           draft,      Swarm BeeSon


### PR DESCRIPTION
[ENS](https://docs.ens.domains) (Ethereum Name Service) encodes [`contenthash()`](https://docs.ens.domains/ensip/7) using multicodec.  The purpose of a `contenthash()` is to describe the web contents for a corresponding ENS name.

Currently, ENS supports IPFS, IPNS, Swarm, Arweave, Onion, etc.  

Example using IPFS:
*  ENS: [`vitalik.eth`](https://app.ens.domains/vitalik.eth) 
*  ENS Web Gateway using Contenthash: [`https://vitalik.eth.limo/`](https://vitalik.eth.limo/) 
* `contenthash()` = `0xe30101701220484da2f7f497cac307e2026282263630b8dd4c448c3436470f5b850b432ba868` 
*  Decoded URL: [`ipfs://k2jmtxt5zh5vu5y8r7em2che3d4ghyftfr6h1yofdhibxai88k1wj5uw`](https://adraffy.github.io/cid.js/test/demo.html#0xe30101701220484da2f7f497cac307e2026282263630b8dd4c448c3436470f5b850b432ba868)
* `0xE3` correspond to multicodec `ipfs`, the following bytes are a CIDv0

We would like to support the following (2) new codecs:

* `0xF2` — **URI**
     * Encoded: `0xf268747470733a2f2f656e732e646f6d61696e732f`
     * Format: `<codec><url: utf8-string>`
     * Decoded URL: `https://ens.domains/` 
* `0xF3` — **Data URL**
     * Encoded: `0xf309746578742f68746d6c3c68746d6c3e68656c6c6f3c2f68746d6c3e`
     * Format: `<len(mime): uint8><mime: ascii-string><data: uint8[]>`
     * Decoded:
          * `mime` = `text/html` (9ch)
          * `data` = `<html>hello</html>` (encoding depends on mime)
