### PR TITLE
add a multicodec to identify Ethereum Solidity ABI-encoded data

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -67,6 +67,7 @@ eth-account-snapshot,           ipld,           0x97,           permanent,  Ethe
 eth-storage-trie,               ipld,           0x98,           permanent,  Ethereum Contract Storage Trie (Eth-Secure-Trie)
 eth-receipt-log-trie,           ipld,           0x99,           draft,      Ethereum Transaction Receipt Log Trie (Eth-Trie)
 eth-receipt-log,                ipld,           0x9a,           draft,      Ethereum Transaction Receipt Log (RLP)
+eth-solidity-abi,               ipld,           0x9b,           draft,      Ethereum Solidity ABI-encoded data
 aes-128,                        key,            0xa0,           draft,      128-bit AES symmetric key
 aes-192,                        key,            0xa1,           draft,      192-bit AES symmetric key
 aes-256,                        key,            0xa2,           draft,      256-bit AES symmetric key


### PR DESCRIPTION
See https://docs.soliditylang.org/en/latest/abi-spec.html.