### PR TITLE
Added ED2K hash and BitTorrent pieces hash (#197)

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -160,8 +160,6 @@ ripemd-128,                     multihash,      0x1052,         draft,
 ripemd-160,                     multihash,      0x1053,         draft,
 ripemd-256,                     multihash,      0x1054,         draft,
 ripemd-320,                     multihash,      0x1055,         draft,
-ed2k,                           multihash,      0x107a,         draft,      eDonkey2000 hash.
-bittorrent-pieces-root,         multihash,      0x107b,         draft,      BitTorrent v2 pieces root hash.
 x11,                            multihash,      0x1100,         draft,
 p256-pub,                       key,            0x1200,         draft,      P-256 public Key (compressed)
 p384-pub,                       key,            0x1201,         draft,      P-384 public Key (compressed)
@@ -548,6 +546,7 @@ ssz,                            serialization,  0xb501,         draft,      Simp
 ssz-sha2-256-bmt,               multihash,      0xb502,         draft,      SSZ Merkle tree root using SHA2-256 as the hashing function and SSZ serialization for the block binary
 sha2-256-chunked,               multihash,      0xb510,         draft,      Hash of concatenated SHA2-256 digests of 8*2^n MiB source chunks; n = ceil(log2(source_size/(10^4 * 8MiB)))
 json-jcs,                       ipld,           0xb601,         draft,      The result of canonicalizing an input according to JCS - JSON Canonicalisation Scheme (RFC 8785)
+bittorrent-pieces-root,         multihash,      0xb702,         draft,      BitTorrent v2 pieces root hash.
 iscc,                           softhash,       0xcc01,         draft,      ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,      0xcert Asset Imprint (root hash)
 nonstandard-sig,                varsig,         0xd000,         deprecated, Namespace for all not yet standard signature algorithms
@@ -558,6 +557,7 @@ bls12_381-g2-sig,               varsig,         0xd0eb,         draft,      G2 s
 eddsa,                          varsig,         0xd0ed,         draft,      Edwards-Curve Digital Signature Algorithm
 eip-191,                        varsig,         0xd191,         draft,      EIP-191 Ethereum Signed Data Standard
 jwk_jcs-pub,                    key,            0xeb51,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the public key. Serialisation based on JCS (RFC 8785)
+ed2k,                           multihash,      0xed20,         draft,      eDonkey2000 hash.
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent,  Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         permanent,  Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)
 shelter-contract-manifest,      shelter,        0x511e00,       draft,      Shelter protocol contract manifest


### PR DESCRIPTION
## Added ED2K hash (#197)

It is mainly used in the eDonkey network. Now it is also used as a file identification code in some netdisk software (such as [115 Netdisk](https://115.com/)).

It is obtained by calculating the MD4 hash of each chunk after dividing, and then concatenating them, and then calculating the MD4 again.

It always generates the same hash result for the same bytes. It is a fixed-length MD4 hash that can be used to uniquely identify the file.

## Added BitTorrent pieces hash.

Because arbitrary key-value pairs can be added to Torrent, it can generate countless InfoHash for the same file. We need to download the InfoHash's metadata to know whether it corresponds to a certain file, and when the InfoHash's seeder is missing in BT network, we will not be able to access the metadata. So it is not actually suitable for constructing CID.

BitTorrent pieces and pieces root are only related to the file content, and we can easily extract it from the Torrent file to construct the CID.

### BitTorrent V1

BTv1 pieces is obtained by calculating the SHA1 hash of each block after [padding (optional)](https://www.bittorrent.org/beps/bep_0047.html) and dividing, and then concatenating them.

When the piece length is determined and there is no padding, it always generates the same hash result for the same bytes and can uniquely identify the file.

When there is padding, it will have hash collision because the padding occurs before chunking. We need to know the file size in addition to uniquely identify the file.

### [BitTorrent V2](https://www.bittorrent.org/beps/bep_0052.html)

BTv2 pieces is obtained by calculating the SHA2-256 hash of each block after dividding, and then merging them as a Merkle tree.

When the piece length is determined, it always generates the same hash result for the same bytes and can uniquely identify the file.

BTv2 pieces root is the final result after merging, which is a fixed-length SHA2-256 hash that can be used to uniquely identify the file.

---

In the eDonkey and BitTorrent networks, these algorithms are used to uniquely identify files, and MD4 and SHA256 are both Multihash. So these algorithms are also `well-established cryptographic hash functions` and should also be Multihash.