### PR TITLE
Add transport-filecoin-piece-http

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -149,6 +149,7 @@ car-multihash-index-sorted,     serialization,  0x0401,         draft,      CARv
 transport-bitswap,              transport,      0x0900,         draft,      Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
 transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
+transport-filecoin-piece-http,  transport,      0x0930,         draft,      HTTP piece retrieval from Filecoin storage provider (typically /piece/CID endpoint)
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
 fr32-sha256-trunc254-padbintree,multihash,      0x1011,         draft,      A balanced binary tree hash used in Filecoin Piece Commitments as described in FRC-0069
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin

--- a/table.csv
+++ b/table.csv
@@ -149,7 +149,7 @@ car-multihash-index-sorted,     serialization,  0x0401,         draft,      CARv
 transport-bitswap,              transport,      0x0900,         draft,      Bitswap datatransfer
 transport-graphsync-filecoinv1, transport,      0x0910,         draft,      Filecoin graphsync datatransfer
 transport-ipfs-gateway-http,    transport,      0x0920,         draft,      HTTP IPFS Gateway trustless datatransfer
-transport-filecoin-piece-http,  transport,      0x0930,         draft,      HTTP piece retrieval from Filecoin storage provider (typically /piece/CID endpoint)
+transport-filecoin-piece-http,  transport,      0x0930,         draft,      HTTP piece retrieval from Filecoin storage provider; https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0066.md
 multidid,                       multiformat,    0x0d1d,         draft,      Compact encoding for Decentralized Identifers
 fr32-sha256-trunc254-padbintree,multihash,      0x1011,         draft,      A balanced binary tree hash used in Filecoin Piece Commitments as described in FRC-0069
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent,  SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin


### PR DESCRIPTION
Intended for IPNI registrations: provider X has piece Y available on `transport-filecoin-piece-http`