### PR TITLE
Support for `CRC-64/NVME` - the default AWS S3 checksum algorithm

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -115,6 +115,7 @@ udt,                            multiaddr,      0x012d,         draft,
 utp,                            multiaddr,      0x012e,         draft,
 crc32,                          hash,           0x0132,         draft,      CRC-32 non-cryptographic hash algorithm (IEEE 802.3)
 crc64-ecma,                     hash,           0x0164,         draft,      CRC-64 non-cryptographic hash algorithm (ECMA-182 - Annex B)
+crc64-nvme,                     hash,           0x0165,         draft,      CRC-64 checksum based on the NVME polynomial as specified in the NVM Express® NVM Command Set Specification
 unix,                           multiaddr,      0x0190,         permanent,
 thread,                         multiaddr,      0x0196,         draft,      Textile Thread
 p2p,                            multiaddr,      0x01a5,         permanent,  libp2p


### PR DESCRIPTION
The default checksum algorithm for new uploaded objects to AWS S3 is `CRC-64/NVME`, according to their documentation: https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html

> Because S3 has default integrity protections, if objects are uploaded without a checksum, S3 automatically attaches the recommended full object CRC-64/NVME (CRC64NVME) checksum algorithm to the object.

_The description and references below were taken from https://github.com/awesomized/crc64fast-nvme:_

CRC-64/NVME comes from the [NVM Express® NVM Command Set Specification](https://nvmexpress.org/wp-content/uploads/NVM-Express-NVM-Command-Set-Specification-1.0d-2023.12.28-Ratified.pdf) (Revision 1.0d, December 2023) and has also been implemented in the [Linux kernel](https://github.com/torvalds/linux/blob/786c8248dbd33a5a7a07f7c6e55a7bfc68d2ca48/lib/crc64.c#L66-L73) (where it's called CRC-64/Rocksoft) and is [AWS S3's recommended checksum option](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html) as CRC64-NVME. (Note that the Check value in the spec uses incorrect endianness [Section 5.2.1.3.4, Figure 120, page 83]).

Other references:
- [crc32-fast](https://crates.io/crates/crc32fast) - Original crc32 implementation in Rust.
- [crc64-fast](https://github.com/tikv/crc64fast) - Original CRC-64/XZ implementation in Rust (from which this project was forked).
- [Fast CRC Computation for Generic Polynomials Using PCLMULQDQ Instruction](https://web.archive.org/web/20131224125630/https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/fast-crc-computation-generic-polynomials-pclmulqdq-paper.pdf) - Intel's paper.
- [NVM Express® NVM Command Set Specification](https://nvmexpress.org/wp-content/uploads/NVM-Express-NVM-Command-Set-Specification-1.0d-2023.12.28-Ratified.pdf) - The NVMe spec, including CRC-64-NVME (with incorrect endian Check value).
- [CRC-64/NVME](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-64-nvme) - The CRC-64/NVME quick definition.
- [Linux implementation](https://github.com/torvalds/linux/blob/786c8248dbd33a5a7a07f7c6e55a7bfc68d2ca48/lib/crc64.c) - Linux implementation of CRC-64/NVME.
- [C++ artifacts implementation](https://github.com/jeffareid/crc/blob/master/crc64r/crc64rg.cpp) - Inspiration C++ for the Rust code in [calculate_pclmulqdq_artifacts.rs](https://github.com/awesomized/crc64fast-nvme/blob/main/src%5Cbin%5Ccalculate_pclmulqdq_artifacts.rs).
- https://github.com/intel/isa-l/issues/88 - Additional insight into generating artifacts.
- [StackOverflow PCLMULQDQ CRC32 answer](https://stackoverflow.com/questions/71328336/fast-crc-with-pclmulqdq-not-reflected/71329114#71329114) - Insightful answer to implementation details for CRC32.
- [StackOverflow PCLMULQDQ CRC32 question](https://stackoverflow.com/questions/21171733/calculating-constants-for-crc32-using-pclmulqdq) - Insightful question & answer to CRC32 implementation details.
- [AWS S3 announcement about CRC64-NVME support](https://aws.amazon.com/blogs/aws/introducing-default-data-integrity-protections-for-new-objects-in-amazon-s3/)
- [AWS S3 docs on checking object integrity using CRC64-NVME](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)
- [Vector Carry-Less Multiplication of Quadwords (VPCLMULQDQ) details](https://en.wikichip.org/wiki/x86/vpclmulqdq)