### PR TITLE
feat: rename kangarootwelve to kt-128, add kt-256 per RFC 9861

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -233,7 +233,8 @@ lamport-sha3-256-sig,           multisig,       0x1a46,         draft,      Lamp
 lamport-sha3-512-sig-share,     multisig,       0x1a54,         draft,      Lamport signature share based on SHA3-512 and split with Shamir gf256
 lamport-sha3-384-sig-share,     multisig,       0x1a55,         draft,      Lamport signature share based on SHA3-384 and split with Shamir gf256
 lamport-sha3-256-sig-share,     multisig,       0x1a56,         draft,      Lamport signature share based on SHA3-256 and split with Shamir gf256
-kangarootwelve,                 multihash,      0x1d01,         draft,      KangarooTwelve is an extendable-output hash function based on Keccak-p
+kt-128,                         multihash,      0x1d01,         draft,      KangarooTwelve KT128 extendable-output hash function (XOF) as defined in RFC 9861
+kt-256,                         multihash,      0x1d02,         draft,      KangarooTwelve KT256 extendable-output hash function (XOF) as defined in RFC 9861
 aes-gcm-256,                    encryption,     0x2000,         draft,      AES Galois/Counter Mode with 256-bit key and 12-byte IV
 silverpine,                     multiaddr,      0x3f42,         draft,      Experimental QUIC over yggdrasil and ironwood routing protocol
 sm3-256,                        multihash,      0x534d,         draft,


### PR DESCRIPTION
[RFC 9861](https://www.rfc-editor.org/rfc/rfc9861) defines two distinct KangarooTwelve functions: KT128 and KT256. They use different Keccak sponge parameters (rate=168 vs rate=136) and produce different digests for the same input. One is not a truncation of the other:

```
  KT128("hello world!", 32) = c571e7ff9fb12b76...
  KT256("hello world!", 32) = de8ccbc63e0f133e...
```

Within each function, shorter outputs are a prefix of longer ones, so variable output length is handled by the multihash length field. But a single code cannot represent both KT128 and KT256 since a verifier would have no way to know which algorithm produced the digest.

- table.csv: rename kangarootwelve (0x1d01) to kt-128
- table.csv: reserve 0x1d02 for kt-256

### Refs

- Originally added in https://github.com/multiformats/multicodec/issues/188 / https://github.com/multiformats/multicodec/pull/192 (cc @tmladek)
- Closes https://github.com/multiformats/multicodec/issues/359 where @bumblefudge suggested adding new code for RFC variant 256
