### PR TITLE
add entries for BIP-340: public/private key and varsig

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -218,6 +218,8 @@ mlkem-512-priv,                 key,            0x1313,         draft,      ML-K
 mlkem-768-priv,                 key,            0x1314,         draft,      ML-KEM 768 public key; as specified by FIPS 203
 mlkem-1024-priv,                key,            0x1315,         draft,      ML-KEM 1024 public key; as specified by FIPS 203
 jwk_jcs-priv,                   key,            0x1316,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the private key. Serialisation based on JCS (RFC 8785)
+bip340-pub,                     key,            0x1340,         draft,      BIP340 public key
+bip340-priv,                    key,            0x1341,         draft,      BIP340 private key
 lamport-sha3-512-pub,           key,            0x1a14,         draft,      Lamport public key based on SHA3-512
 lamport-sha3-384-pub,           key,            0x1a15,         draft,      Lamport public key based on SHA3-384
 lamport-sha3-256-pub,           key,            0x1a16,         draft,      Lamport public key based on SHA3-256
@@ -613,6 +615,7 @@ es256,                          varsig,         0xd01200,       draft,      ES25
 es384,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm
 rs256,                          varsig,         0xd01205,       draft,      RS256 Signature Algorithm
+bip340,                         varsig,         0xd01206,       draft,      BIP340 Signature Algorithm
 es256k-msig,                    multisig,       0xd01300,       draft,      ES256K (secp256k1) Signature as Multisig
 bls12_381-g1-msig,              multisig,       0xd01301,       draft,      G1 signature for BLS-12381-G2 as Multisig
 bls12_381-g2-msig,              multisig,       0xd01302,       draft,      G2 signature for BLS-12381-G1 as Multisig


### PR DESCRIPTION
While bip340 operates on secp256k1, it makes sense to have separate values:
- public keys have a different format: 32-byte x-only (bip340) vs 33-byte prefix+x (secp256k1)
- private keys have the same format but different usage expectation
- algorithm are different: schnorr (bip340) vs ECDSA (secp256k1)
- signatures have a different format: 64-byte [R.x, s] (bip340) vs 64-byte [r, s] (secp256k1)

That is, they can't reasonable mix or interoperate.

I tried to pick values that makes sense, let me know if I should change them.