### PR TITLE
Add adnl codec for TON network addresses

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -611,7 +611,7 @@ massa-gossip,                   namespace,      0xb59914,       draft,      Mass
 massa-mns,                      namespace,      0xb59915,       draft,      Massa Name Service target
 massa-sc,                       namespace,      0xb59916,       draft,      Massa smart-contract address target
 massa-gossip-id,                namespace,      0xb59917,       draft,      Massa Gossip ID target
-adnl,                           namespace,      0xb69910,       draft,      TON ADNL network address (32-byte Ed25519-derived peer identifier)
+adnl,                           namespace,      0xb69910,       draft,      TON ADNL address: 32-byte SHA-256(0x4813b4c6_LE || Ed25519-pubkey)
 es256,                          varsig,         0xd01200,       draft,      ES256 Signature Algorithm
 es384,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm

--- a/table.csv
+++ b/table.csv
@@ -611,6 +611,7 @@ massa-gossip,                   namespace,      0xb59914,       draft,      Mass
 massa-mns,                      namespace,      0xb59915,       draft,      Massa Name Service target
 massa-sc,                       namespace,      0xb59916,       draft,      Massa smart-contract address target
 massa-gossip-id,                namespace,      0xb59917,       draft,      Massa Gossip ID target
+adnl,                           namespace,      0xb69910,       draft,      TON ADNL network address (32-byte Ed25519-derived peer identifier)
 es256,                          varsig,         0xd01200,       draft,      ES256 Signature Algorithm
 es384,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm


### PR DESCRIPTION
Add multicodec namespace entry for TON ADNL addresses in the 0xbX9910 range following the existing namespace convention (alongside skynet, arweave, subspace, kumandra, massa).

What is ADNL?

ADNL (Abstract Datagram Network Layer) is TON's peer-to-peer networking protocol. An ADNL address is a 32-byte identifier computed as `SHA-256(TL_constructor_id || pubkey)`, where the TL constructor id for `pub.ed25519` is `0x4813b4c6` serialized little-endian (wire bytes `c6 b4 13 48`), followed by the 32-byte Ed25519 public key. Reference: `ton-blockchain/ton` — `keys/keys.cpp::compute_short_id()`.

https://docs.ton.org/develop/network/adnl-udp

Codec added:

│ 0xb69910 │ adnl │ TON ADNL address: 32-byte SHA-256(0x4813b4c6_LE || Ed25519-pubkey)

Motivation

This codec enables ENSIP-7 contenthash encoding for TON sites, allowing `.eth` domains to resolve to TON resources through standard content-addressed URIs.

Reference implementation: https://github.com/TONresistor/Tonutils-Proxy/blob/contenthash/resolver/contenthash.go
Live example: tonnet.eth contenthash set on Ethereum mainnet