### PR TITLE
feat: add jwk and jwk-set key codecs

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -36,6 +36,8 @@ dns,                            multiaddr,      0x35,           permanent,
 dns4,                           multiaddr,      0x36,           permanent,
 dns6,                           multiaddr,      0x37,           permanent,
 dnsaddr,                        multiaddr,      0x38,           permanent,
+jwk,                            key,            0x44,           draft,      JSON-encoded JSON Web Key (JWK) per IETF RFC 7517 section 4; media type application/jwk+json; kty/alg/crv parameters identify the key algorithm; may carry public or private key material depending on which parameters are present
+jwk-set,                        key,            0x45,           draft,      JSON-encoded JWK Set per IETF RFC 7517 section 5; media type application/jwk-set+json; JSON object containing keys array of JWKs; each element processed independently
 protobuf,                       serialization,  0x50,           draft,      Protocol Buffers
 cbor,                           ipld,           0x51,           permanent,  CBOR
 raw,                            ipld,           0x55,           permanent,  raw binary


### PR DESCRIPTION
## Summary

Adds two self-describing JSON key container codecs, the JSON twin of the `cose-key`/`cose-key-set` pair proposed in #400.

| name | code | format | spec |
| --- | --- | --- | --- |
| `jwk` | `0x44` | JSON-encoded JSON Web Key (`application/jwk+json`) | [RFC 7517 §4](https://www.rfc-editor.org/rfc/rfc7517#section-4) |
| `jwk-set` | `0x45` | JSON-encoded JWK Set (`application/jwk-set+json`) | [RFC 7517 §5](https://www.rfc-editor.org/rfc/rfc7517#section-5) |

The payload identifies its own algorithm via the `kty`/`alg`/`crv` parameters. The same container carries public or private key material; private parameters (`d`, `p`, `q`, `dp`, `dq`, `qi`) mark a private key.

Suggested by @achingbrain in [#400 (comment)](https://github.com/multiformats/multicodec/pull/400#issuecomment-4353831790).

## Motivation

Same as #400: stop gating new key types in libp2p peer IDs and IPNS records on per-algorithm multicodec registrations. Once IETF/IANA registers a new `kty`/`alg` value, JWK producers can emit it and JWK consumers can parse it. No multicodec update required.

JSON web stacks already speak JWK everywhere: OAuth and OIDC JWKS endpoints, WebCrypto's `importKey`/`exportKey`, every JOSE library, WebAuthn passkey enrollment. `cose-key` covers the CBOR-native side of the same story; `jwk` covers the JSON-native side and lets JS and web stacks participate without a CBOR dependency.

## Relationship to existing `jwk_jcs-pub` / `jwk_jcs-priv`

The registry already contains:

- `jwk_jcs-pub` (`0xeb51`)
- `jwk_jcs-priv` (`0x1316`)

Those constrain the format on purpose: required-members-only JWK, JCS-canonicalized per RFC 8785. They give peer-ID-style identifiers a deterministic encoding, so the same key always hashes to the same bytes.

The new `jwk`/`jwk-set` codecs complement them as the loose-container counterparts:

- `jwk` / `jwk-set`: any well-formed RFC 7517 JWK or JWK Set, arbitrary members allowed, no canonicalization promised. Use when wrapping or referencing an as-is JWK (a JWKS fetched from an OIDC provider, a WebCrypto export, a JWK with `kid`/`use`/`x5c` metadata).
- `jwk_jcs-pub` / `jwk_jcs-priv`: minimal, canonical, deterministic. Use when the codec output is the identifier itself (peer IDs, content addressing of bare keys).

`cose-key` (loose) lacks a canonical-subset codec too, so the same asymmetry already exists on the CBOR side.

## Code placement

`0x44` and `0x45` extend the single-byte block #400 establishes at `0x40`-`0x43`. All six codes stay single-byte varints (`< 0x80`), so identifiers built on top (peer IDs, IPNS names) keep the one-byte prefix forever. Same argument as #400.

The existing `jwk_jcs-*` codes sit at two-byte varints (`0x1316`, `0xeb51`); a single-byte option is genuinely new real estate, not duplication.

## Dependencies

This PR touches `0x44`-`0x45`; #400 touches `0x40`-`0x43`. The diffs are independent. If #400 lands first, the four containers sit consecutively. If this lands first, `0x40`-`0x43` stay vacant until #400 merges. No conflict either way.