### PR TITLE
Add `radicle` namespace

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -247,6 +247,7 @@ aes-gcm-256,                    encryption,     0x2000,         draft,      AES 
 silverpine,                     multiaddr,      0x3f42,         draft,      Experimental QUIC over yggdrasil and ironwood routing protocol
 sm3-256,                        multihash,      0x534d,         draft,
 sha256a,                        hash,           0x7012,         draft,      The sum of multiple sha2-256 hashes; as specified by Ceramic CIP-124.
+radicle,                        namespace,      0x8776,         draft,      Radicle namespace
 chacha20-poly1305,              multikey,       0xa000,         draft,      ChaCha20_Poly1305 encryption scheme
 blake2b-8,                      multihash,      0xb201,         draft,      Blake2b consists of 64 output lengths that give different hashes
 blake2b-16,                     multihash,      0xb202,         draft,


### PR DESCRIPTION
[Radicle](https://radicle.dev) is an open source, peer-to-peer code collaboration stack built on Git.

Repositories are addressed by hashing their initial "Repository Identity Document".

In order to allow addressing repositories by CIDs, reserve a new code.

For example, we currently use rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5 to address the repository which you can view on the web at https://radicle.network/nodes/seed.radicle.dev/rad%3Az3gqcJUoA1n9HaHKufZs5FCSGazv5.
The identifier here is what we call a "Repository Identifier" and it is a plain base56btc encoding of a special Git object in that repository.

With the imminent introduction of SHA-256 as the default object format/hash function in Git 3, we plan to introduce more flexibility into our repository identifier scheme. CIDs with this multicodec code look very promising.