### PR TITLE
Fix some description typos on keys

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -44,7 +44,7 @@ rlp,                            serialization,  0x60,           draft,      recu
 bencode,                        serialization,  0x63,           draft,      bencode
 dag-pb,                         ipld,           0x70,           permanent,  MerkleDAG protobuf
 dag-cbor,                       ipld,           0x71,           permanent,  MerkleDAG cbor
-libp2p-key,                     ipld,           0x72,           permanent,  Libp2p Public Key
+libp2p-key,                     ipld,           0x72,           permanent,  Libp2p public key
 git-raw,                        ipld,           0x78,           permanent,  Raw Git object
 torrent-info,                   ipld,           0x7b,           draft,      Torrent file info field (bencoded)
 torrent-file,                   ipld,           0x7c,           draft,      Torrent file (bencoded)
@@ -164,11 +164,11 @@ ripemd-160,                     multihash,      0x1053,         draft,
 ripemd-256,                     multihash,      0x1054,         draft,
 ripemd-320,                     multihash,      0x1055,         draft,
 x11,                            multihash,      0x1100,         draft,
-p256-pub,                       key,            0x1200,         draft,      P-256 public Key (compressed)
-p384-pub,                       key,            0x1201,         draft,      P-384 public Key (compressed)
-p521-pub,                       key,            0x1202,         draft,      P-521 public Key (compressed)
-ed448-pub,                      key,            0x1203,         draft,      Ed448 public Key
-x448-pub,                       key,            0x1204,         draft,      X448 public Key
+p256-pub,                       key,            0x1200,         draft,      P-256 public key (compressed)
+p384-pub,                       key,            0x1201,         draft,      P-384 public key (compressed)
+p521-pub,                       key,            0x1202,         draft,      P-521 public key (compressed)
+ed448-pub,                      key,            0x1203,         draft,      Ed448 public key
+x448-pub,                       key,            0x1204,         draft,      X448 public key
 rsa-pub,                        key,            0x1205,         draft,      RSA public key. DER-encoded ASN.1 type RSAPublicKey according to IETF RFC 8017 (PKCS #1)
 sm2-pub,                        key,            0x1206,         draft,      SM2 public key (compressed)
 vlad,                           vlad,           0x1207,         draft,      Verifiable Long-lived ADdress

--- a/table.csv
+++ b/table.csv
@@ -215,8 +215,8 @@ sm2-priv,                       key,            0x1310,         draft,      SM2 
 ed448-priv,                     key,            0x1311,         draft,      Ed448 private key
 x448-priv,                      key,            0x1312,         draft,      X448 private key
 mlkem-512-priv,                 key,            0x1313,         draft,      ML-KEM 512 private key; as specified by FIPS 203
-mlkem-768-priv,                 key,            0x1314,         draft,      ML-KEM 768 public key; as specified by FIPS 203
-mlkem-1024-priv,                key,            0x1315,         draft,      ML-KEM 1024 public key; as specified by FIPS 203
+mlkem-768-priv,                 key,            0x1314,         draft,      ML-KEM 768 private key; as specified by FIPS 203
+mlkem-1024-priv,                key,            0x1315,         draft,      ML-KEM 1024 private key; as specified by FIPS 203
 jwk_jcs-priv,                   key,            0x1316,         draft,      JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the private key. Serialisation based on JCS (RFC 8785)
 mldsa-44-priv,                  key,            0x1317,         draft,      ML-DSA 44 private key; expanded key format (2560 bytes) as specified by FIPS 204
 mldsa-65-priv,                  key,            0x1318,         draft,      ML-DSA 65 private key; expanded key format (4032 bytes) as specified by FIPS 204


### PR DESCRIPTION
I think these are uncontroversial:

* [fix: `mlkem-*-priv` descriptions should say "private key"](https://github.com/multiformats/multicodec/commit/af3568601cde16bc8c8b754ef98536a717165286)
* [fix: Standardize on lower-case "public key"](https://github.com/multiformats/multicodec/commit/1a65e2914dd27063dbeb6ea11f61654fbd5f6c7d)
