### PR TITLE
Add ton-storage namespace codec

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -632,6 +632,7 @@ massa-mns,                      namespace,      0xb59915,       draft,      Mass
 massa-sc,                       namespace,      0xb59916,       draft,      Massa smart-contract address target
 massa-gossip-id,                namespace,      0xb59917,       draft,      Massa Gossip ID target
 adnl,                           namespace,      0xb69910,       draft,      TON ADNL address: 32-byte SHA-256(0x4813b4c6_LE || Ed25519-pubkey)
+ton-storage,                    namespace,      0xb79910,       draft,      TON Storage BagID: 32-byte representation hash of a TorrentInfo cell
 es256,                          varsig,         0xd01200,       draft,      ES256 Signature Algorithm
 es384,                          varsig,         0xd01201,       draft,      ES384 Signature Algorithm
 es512,                          varsig,         0xd01202,       draft,      ES512 Signature Algorithm


### PR DESCRIPTION
Add a `ton-storage` namespace codec for TON Storage BagIDs.

| Code | Name | Tag | Payload |
|---|---|---|---|
| `0xb79910` | `ton-storage` | `namespace` | 32-byte TON Storage BagID |

TON ADNL addresses already have a dedicated multicodec allocation:
[`adnl` (`0xb69910`), added in #402](https://github.com/multiformats/multicodec/pull/402).

ADNL addresses are address-based identifiers for TON network endpoints. TON
Storage BagIDs are content-based identifiers derived from a bag's `TorrentInfo`
cell. Although both are 32 bytes, they require different resolution flows, so
this PR adds a dedicated `ton-storage` codec instead of reusing `adnl`.

TON Storage is TON's distributed file storage network. Files are organized into
bags, each identified by a 256-bit BagID.

A BagID is the 32-byte representation hash of the bag's `TorrentInfo` cell. It is
the native identifier used by TON Storage clients and by TON DNS
`dns_storage_address` records.

Binary payload:

```text
bag_id[32]
```

When used as an ENSIP-7 contenthash:

```text
uvarint(0xb79910) || bag_id[32]
```

The canonical user-facing URI is:

```text
tonstorage://<64-hex-character BagID>
```

This allocation enables TON Storage BagIDs to be represented as self-describing
content addresses, including in ENSIP-7 contenthash records.

Existing implementations and clients include:

- [ton-blockchain/ton](https://github.com/ton-blockchain/ton)
- [xssnick/tonutils-storage](https://github.com/xssnick/tonutils-storage)
- [xssnick/TON-Torrent](https://github.com/xssnick/TON-Torrent)

Sources:

- [TON Storage documentation](https://docs.ton.org/foundations/web3/ton-storage)
- [TON DNS standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0081-dns-standard.md)
